### PR TITLE
infra: [#16] GitHub Actions을 사용한 CI/CD 구현

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,49 @@
+name: CI Build
+
+on:
+  pull_request:
+    branches: [ "main" ]
+  push:
+    branches: [ "main" ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+
+      - name: Run Tests
+        run: ./gradlew test
+
+      - name: Run Checkstyle
+        run: ./gradlew checkstyleMain
+
+      - name: Build Project
+        run: ./gradlew clean build -x test
+
+      - name: GitHub Secrets To .env
+        run: |
+          echo "DB_TYPE=mysql" >> .env
+          echo "DB_HOST=${{ secrets.DB_HOST }}" >> .env
+          echo "DB_PORT=${{ secrets.DB_PORT }}" >> .env
+          echo "DB_NAME=${{ secrets.DB_NAME }}" >> .env
+          echo "DB_USERNAME=${{ secrets.DB_USERNAME }}" >> .env
+          echo "DB_PASSWORD=${{ secrets.DB_PASSWORD }}" >> .env
+          echo "STORAGE_BUCKET=${{ secrets.STORAGE_BUCKET }}" >> .env
+          echo "STORAGE_BASE_URL=${{ secrets.STORAGE_BASE_URL }}" >> .env
+
+      - name: Upload Artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: app-jar
+          path: |
+            build/libs/*.jar
+            .env

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -1,0 +1,40 @@
+name: CD Deploy
+
+on:
+  workflow_run:
+    workflows: [ "CI Build" ]
+    types:
+      - completed
+
+jobs:
+  deploy:
+    # 이전 작업 성공 + main에서만 배포 실행
+    if: ${{ github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.head_branch == 'main' }}
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Download artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: app-jar
+
+      - name: Copy artifact to EC2
+        uses: appleboy/scp-action@v0.1.7
+        with:
+          host: ${{ secrets.EC2_HOST }}
+          username: ubuntu
+          key: ${{ secrets.EC2_PRIVATE_KEY }}
+          source: |
+            "*.jar"
+            ".env"
+          target: "~/backend"
+
+      - name: Run reload.sh
+        uses: appleboy/ssh-action@v0.1.10
+        with:
+          host: ${{ secrets.EC2_HOST }}
+          username: ubuntu
+          key: ${{ secrets.EC2_PRIVATE_KEY }}
+          script: |
+            chmod +x ~/reload.sh
+            ~/reload.sh

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -5,7 +5,7 @@ spring:
         access-key: ${AWS_ACCESS_KEY}
         secret-key: ${AWS_SECRET_KEY}
       region:
-        static: ${AWS_STATIC_REGION}
+        static: ${AWS_STATIC_REGION:ap-northeast-2}
   config:
     import: optional:file:.env
   autoconfigure:
@@ -47,9 +47,11 @@ decorator:
       multiline: true
 
 springdoc:
+  api-docs:
+    enabled: true
   swagger-ui:
     path: ${SWAGGER_PATH:/swagger-ui.html}
-    
+
 app:
   storage:
     bucket: ${STORAGE_BUCKET}


### PR DESCRIPTION
## #️⃣ 연관된 이슈
closed #16 

## 📝 작업 내용
- `reload.sh` 스크립트를 작성하여 EC2에서 Spring Boot 앱 자동 재시작 구조로 구현하였습니다.
- GitHub Secrets를 활용해 DB, S3 등 민감한 설정값을 주입하는 방식을 선택했습니다.
  - .env 파일을 CI 단계에서 자동 생성 후 .jar 파일과 함께 EC2에 전달하는 방식으로 구현했습니다.
- GitHub Actions 기반 CI/CD 워크플로우 구성 (build.yaml, deploy.yaml)
  - CI: 테스트, 체크스타일 검사, 빌드 및 아티팩트 업로드 후 build하도록 했습니다.
  - CD: CI 성공 시 EC2에 배포 및 재시작 자동화하였습니다.

## 💬 리뷰 요구사항(선택)
- application.yaml에 `AWS_REGION` 부분은 기본값으로 `ap-northeast-2`로 설정하여 secrets의 저장을 줄였습니다!
  - 변수 저장되는 양이 너무 많은 것 같아 기본값으로 하는 것으로 하였는데 이 부분도 secrets에 추가하는 게 좋을까요??


### 📌 PR 진행 시 참고사항
테스트 코드 변경점이 있어서 해당 부분 업데이트 후, 따로 리뷰 부탁드리겠습니다!! 

- 리뷰어는 좋은 코드 방향을 제시하되, **수정을 강요하지 않습니다.**
- 좋은 코드를 발견하면 **칭찬과 격려를 아끼지 않습니다.**
- 리뷰는 Reviewer로 지정된 시점 기준으로 **3일 이내**에 진행해 주세요.
- Comment 작성 시 아래 Prefix를 사용해 주세요:
    - `P1`: 꼭 반영해 주세요 (Request Changes) – 이슈나 취약점 관련
    - `P2`: 반영을 고려해 주세요 (Comment) – 개선 의견
    - `P3`: 단순 제안 (Chore)