### PR TITLE
cicd: [#16] cd 내부 job: copy artifact 할 때, .env와 jar파일 생성된 위치를 명확히 선언

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -4,7 +4,7 @@ name: CD Deploy
 # PR이 main 브랜치로 merge될 때만 실행
 on:
   pull_request:
-    types: [closed]
+    types: [ closed ]
     branches: [ "main" ]
 
 jobs:
@@ -40,6 +40,7 @@ jobs:
 
       # 환경 변수 설정
       - name: GitHub Secrets To .env
+        working-directory: backend
         run: |
           echo "DB_TYPE=mysql" >> .env
           echo "DB_HOST=${{ secrets.DB_HOST }}" >> .env
@@ -57,8 +58,8 @@ jobs:
           username: ubuntu
           key: ${{ secrets.EC2_PRIVATE_KEY }}
           source: |
-            build/libs/green*.jar
-            .env
+            backend/build/libs/green*.jar
+            backend/.env
           target: "~/backend"
 
       - name: Run reload.sh


### PR DESCRIPTION
## #️⃣ 연관된 이슈
#16 

## 📝 작업 내용
- cd 내부 job: copy artifact 할 때, .env와 jar파일 생성된 위치를 명확히 선언

## 💬 리뷰 요구사항(선택)


### 📌 PR 진행 시 참고사항
- 리뷰어는 좋은 코드 방향을 제시하되, **수정을 강요하지 않습니다.**
- 좋은 코드를 발견하면 **칭찬과 격려를 아끼지 않습니다.**
- 리뷰는 Reviewer로 지정된 시점 기준으로 **3일 이내**에 진행해 주세요.
- Comment 작성 시 아래 Prefix를 사용해 주세요:
    - `P1`: 꼭 반영해 주세요 (Request Changes) – 이슈나 취약점 관련
    - `P2`: 반영을 고려해 주세요 (Comment) – 개선 의견
    - `P3`: 단순 제안 (Chore)