### PR TITLE
feat: [#56] 서비스 통합테스트 작성 및 DB 연결을 위한 비즈니스 로직 구현

### DIFF
--- a/src/main/java/com/example/green/domain/info/controller/api/InfoResponseMessage.java
+++ b/src/main/java/com/example/green/domain/info/controller/api/InfoResponseMessage.java
@@ -5,7 +5,6 @@ import com.example.green.global.api.ResponseMessage;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
-// TODO 응답값 만드는 건 엄밀히 말하면 inport 는 아니긴 함 오히려 outport 에 가깝지만 presentation controller 계층 사용
 @Getter
 @AllArgsConstructor
 public enum InfoResponseMessage implements ResponseMessage {

--- a/src/main/java/com/example/green/domain/info/domain/InfoEntity.java
+++ b/src/main/java/com/example/green/domain/info/domain/InfoEntity.java
@@ -70,7 +70,7 @@ public class InfoEntity extends BaseEntity {
 		this.content = content;
 		this.infoCategory = infoCategory;
 		this.imageUrl = imageUrl;
-		this.isDisplay = validateFormatIsDisplay(isDisplay);
+		this.isDisplay = determineIsDisplay(isDisplay.trim());
 	}
 
 	// 변수 직접 받아 필드 변경 -> 도미엔단 외부 영향도 최소화
@@ -86,7 +86,7 @@ public class InfoEntity extends BaseEntity {
 		this.content = updateContent;
 		this.infoCategory = updateInfoCategory;
 		this.imageUrl = updateImageUrl;
-		this.isDisplay = validateFormatIsDisplay(updateIsDisplay);
+		this.isDisplay = determineIsDisplay(updateIsDisplay.trim());
 	}
 
 	private void validateNullInfo(
@@ -101,14 +101,10 @@ public class InfoEntity extends BaseEntity {
 		EntityValidator.validateEmptyString(isDisplay, "전시 여부는 필수입니다.");
 	}
 
-	private String validateFormatIsDisplay(String isDisplay) {
-		if ("y".equalsIgnoreCase(isDisplay)) {
-			isDisplay = "Y";
-		} else if ("n".equalsIgnoreCase(isDisplay)) {
-			isDisplay = "N";
-		} else {
+	private String determineIsDisplay(String isDisplay) {
+		if (!isDisplay.equalsIgnoreCase("Y") && !isDisplay.equalsIgnoreCase("N")) {
 			throw new BusinessException(GlobalExceptionMessage.UNPROCESSABLE_ENTITY);
 		}
-		return isDisplay;
+		return isDisplay.toUpperCase();
 	}
 }

--- a/src/main/java/com/example/green/domain/info/domain/vo/InfoCategory.java
+++ b/src/main/java/com/example/green/domain/info/domain/vo/InfoCategory.java
@@ -10,9 +10,9 @@ import lombok.Getter;
 @Getter
 @AllArgsConstructor
 public enum InfoCategory {
-	PARTICIPANT("참여형"),
+	EVENT("이벤트"),
 	CONTENTS("콘텐츠"),
-	COMMUNITIY("커뮤니티");
+	ETC("기타");
 
 	private final String description;
 

--- a/src/main/java/com/example/green/domain/info/dto/admin/InfoSearchResponseByAdmin.java
+++ b/src/main/java/com/example/green/domain/info/dto/admin/InfoSearchResponseByAdmin.java
@@ -10,7 +10,7 @@ import com.example.green.domain.info.domain.InfoEntity;
 public record InfoSearchResponseByAdmin(
 	String id,
 	String title,
-	String infoCategoryName, // @JsonValue로 Json직렬화 단계 확인 가능 but 명시적인 방법 채택
+	String infoCategoryName,
 	String createdBy,
 	String isDisplay,
 	LocalDateTime createdDate // TODO [확인필요] Date 타입 프론트
@@ -20,7 +20,7 @@ public record InfoSearchResponseByAdmin(
 		return new InfoSearchResponseByAdmin(
 			e.getId(),
 			e.getTitle(),
-			e.getInfoCategory().getDescription(),
+			e.getInfoCategory().getDescription(),// @JsonValue 대신 명시적인 방법으로 사용
 			e.getCreatedBy(),
 			e.getIsDisplay(),
 			e.getCreatedDate()

--- a/src/main/java/com/example/green/domain/info/dto/user/InfoDetailResponseByUser.java
+++ b/src/main/java/com/example/green/domain/info/dto/user/InfoDetailResponseByUser.java
@@ -7,14 +7,14 @@ import com.example.green.domain.info.domain.InfoEntity;
  * */
 public record InfoDetailResponseByUser(
 	String id,
-	String infoCategoryName, // @JsonValue로 Json직렬화 단계 확인 가능 but 명시적인 방법 채택
+	String infoCategoryName,
 	String title
 
 ) {
 	public static InfoDetailResponseByUser from(InfoEntity e) {
 		return new InfoDetailResponseByUser(
-			e.getInfoCategory().getDescription(),
 			e.getId(),
+			e.getInfoCategory().getDescription(),// @JsonValue 대신 명시적인 방법으로 사용
 			e.getTitle()
 		);
 	}

--- a/src/main/java/com/example/green/domain/info/dto/user/InfoSearchResponseByUser.java
+++ b/src/main/java/com/example/green/domain/info/dto/user/InfoSearchResponseByUser.java
@@ -7,14 +7,14 @@ import com.example.green.domain.info.domain.InfoEntity;
  * */
 public record InfoSearchResponseByUser(
 	String id,
-	String infoCategoryName, // @JsonValue로 Json직렬화 단계 확인 가능 but 명시적인 방법 채택
+	String infoCategoryName,
 	String title
 
 ) {
 	public static InfoSearchResponseByUser from(InfoEntity e) {
 		return new InfoSearchResponseByUser(
-			e.getInfoCategory().getDescription(),
 			e.getId(),
+			e.getInfoCategory().getDescription(),// @JsonValue 대신 명시적인 방법으로 사용
 			e.getTitle()
 		);
 	}

--- a/src/main/java/com/example/green/domain/info/exception/InfoExceptionMessage.java
+++ b/src/main/java/com/example/green/domain/info/exception/InfoExceptionMessage.java
@@ -13,7 +13,7 @@ import lombok.Getter;
 @Getter
 public enum InfoExceptionMessage implements ExceptionMessage {
 	INVALID_CATEGORY_CODE(BAD_REQUEST, "유효하지 않은 카테고리 코드입니다."),
-	INVALID_INFO_NUMBER(BAD_REQUEST, "해당 정보 번호의 내요은 찾을 수 없습니다."),
+	INVALID_INFO_NUMBER(BAD_REQUEST, "해당 정보 번호의 내용은 찾을 수 없습니다."),
 	CANNOT_MAKE_INFO_ID(INTERNAL_SERVER_ERROR, "정보 ID 생성 중 오류가 발생했습니다.");
 
 	private final HttpStatus httpStatus;

--- a/src/main/java/com/example/green/domain/info/repository/InfoRepository.java
+++ b/src/main/java/com/example/green/domain/info/repository/InfoRepository.java
@@ -1,4 +1,12 @@
 package com.example.green.domain.info.repository;
 
-public interface InfoRepository {
+import java.util.List;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.example.green.domain.info.domain.InfoEntity;
+
+public interface InfoRepository extends JpaRepository<InfoEntity, String> {
+	List<InfoEntity> findAllByOrderByCreatedDateDesc();
 }
+

--- a/src/main/java/com/example/green/domain/info/service/InfoService.java
+++ b/src/main/java/com/example/green/domain/info/service/InfoService.java
@@ -1,7 +1,46 @@
 package com.example.green.domain.info.service;
 
-/**
- * InfoService의 확장가능성은 낮기 때문에 추상화하지 않고 구체클래스 직접 사용
- * */
-public class InfoService {
+import com.example.green.domain.info.dto.InfoRequest;
+import com.example.green.domain.info.dto.admin.InfoDetailResponseByAdmin;
+import com.example.green.domain.info.dto.admin.InfoSearchListResponseByAdmin;
+import com.example.green.domain.info.dto.admin.InfoSearchResponseByAdmin;
+import com.example.green.domain.info.dto.user.InfoDetailResponseByUser;
+import com.example.green.domain.info.dto.user.InfoSearchListResponseByUser;
+
+public interface InfoService {
+	/**
+	 * 관리자 전체 Info 페이지 단위로 조회
+	 */
+	InfoSearchListResponseByAdmin getInfosForAdmin(int page, int size);
+
+	/**
+	 * 관리자 Info 상세 페이지 조회
+	 */
+	InfoSearchResponseByAdmin getInfoDetailForAdmin(String id);
+
+	/**
+	 * 관리자 Info 등록
+	 */
+	InfoDetailResponseByAdmin saveInfo(InfoRequest saveRequest);
+
+	/**
+	 * 관리자 Info 수정
+	 */
+	InfoDetailResponseByAdmin updateInfo(String id, InfoRequest updateRequest);
+
+	/**
+	 * 관리자 Info 삭제
+	 */
+	void deleteInfo(String deleteInfoId);
+
+	/**
+	 * 일반 사용자 노출 가능한 Info 전체 조회 (페이징 없음)
+	 */
+	InfoSearchListResponseByUser getInfosForUser();
+
+	/**
+	 * 로그인한 사용자 Info 상세 페이지 조회
+	 */
+	InfoDetailResponseByUser getInfoDetailForUser(String id);
+
 }

--- a/src/main/java/com/example/green/domain/info/service/InfoServiceImpl.java
+++ b/src/main/java/com/example/green/domain/info/service/InfoServiceImpl.java
@@ -1,0 +1,126 @@
+package com.example.green.domain.info.service;
+
+import java.util.List;
+
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.example.green.domain.common.service.FileManager;
+import com.example.green.domain.info.domain.InfoEntity;
+import com.example.green.domain.info.dto.InfoPage;
+import com.example.green.domain.info.dto.InfoRequest;
+import com.example.green.domain.info.dto.admin.InfoDetailResponseByAdmin;
+import com.example.green.domain.info.dto.admin.InfoSearchListResponseByAdmin;
+import com.example.green.domain.info.dto.admin.InfoSearchResponseByAdmin;
+import com.example.green.domain.info.dto.user.InfoDetailResponseByUser;
+import com.example.green.domain.info.dto.user.InfoSearchListResponseByUser;
+import com.example.green.domain.info.dto.user.InfoSearchResponseByUser;
+import com.example.green.domain.info.exception.InfoException;
+import com.example.green.domain.info.exception.InfoExceptionMessage;
+import com.example.green.domain.info.repository.InfoRepository;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+
+@Log4j2
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class InfoServiceImpl implements InfoService {
+
+	private final InfoRepository infoRepository;
+	private final FileManager fileManager;
+
+	// TODO [확인필요] 사이즈가 0일때는 프론트 처리
+	@Override
+	@Transactional(readOnly = true)
+	public InfoSearchListResponseByAdmin getInfosForAdmin(int page, int size) {
+		PageRequest pageable = PageRequest.of(page, size, Sort.by("createdDate").descending());
+		Page<InfoEntity> infoList = infoRepository.findAll(pageable);
+
+		List<InfoSearchResponseByAdmin> contentResult = infoList.getContent().stream()
+			.map(InfoSearchResponseByAdmin::from)
+			.toList();
+
+		InfoPage pageResult = new InfoPage(
+			infoList.getTotalElements(),
+			infoList.getTotalPages()
+		);
+
+		return new InfoSearchListResponseByAdmin(contentResult, pageResult);
+	}
+
+	@Override
+	@Transactional(readOnly = true)
+	public InfoSearchResponseByAdmin getInfoDetailForAdmin(String infoId) {
+		InfoEntity infoEntity = getInfoEntity(infoId);
+		return InfoSearchResponseByAdmin.from(infoEntity);
+	}
+
+	@Override
+	public InfoDetailResponseByAdmin saveInfo(InfoRequest saveRequest) {
+		InfoEntity infoEntity = infoRepository.save(saveRequest.toEntity());
+		fileManager.confirmUsingImage(saveRequest.imageUrl());
+		log.info("[InfoServiceImpl] 정보공유 등록합니다. 정보공유 번호: {}", infoEntity.getId());
+		return InfoDetailResponseByAdmin.from(infoEntity);
+	}
+
+	@Override
+	public InfoDetailResponseByAdmin updateInfo(String infoId, InfoRequest updateRequest) {
+		InfoEntity infoEntity = getInfoEntity(infoId);
+		if (StringUtils.isNotEmpty(infoEntity.getImageUrl())) {
+			fileManager.unUseImage(infoEntity.getImageUrl());
+		}
+		log.info("[InfoServiceImpl] 정보공유 수정합니다. 정보공유 번호: {}", infoEntity.getId());
+		makeUpdateEntity(updateRequest, infoEntity);
+		fileManager.confirmUsingImage(updateRequest.imageUrl());
+		return InfoDetailResponseByAdmin.from(infoEntity);
+	}
+
+	@Override
+	public void deleteInfo(String infoId) {
+		InfoEntity infoEntity = getInfoEntity(infoId);
+		log.info("[InfoServiceImpl] 정보공유 삭제합니다. 정보공유 번호: {}", infoEntity.getId());
+		infoEntity.markDeleted();
+		fileManager.unUseImage(infoEntity.getImageUrl());
+	}
+
+	@Override
+	@Transactional(readOnly = true)
+	public InfoSearchListResponseByUser getInfosForUser() {
+		List<InfoEntity> infoList = infoRepository.findAllByOrderByCreatedDateDesc();
+		return new InfoSearchListResponseByUser(
+			infoList.stream()
+				.map(InfoSearchResponseByUser::from)
+				.toList()
+		);
+	}
+
+	@Override
+	@Transactional(readOnly = true)
+	public InfoDetailResponseByUser getInfoDetailForUser(String id) {
+		InfoEntity infoEntity = getInfoEntity(id);
+		return InfoDetailResponseByUser.from(infoEntity);
+	}
+
+	private InfoEntity getInfoEntity(String infoId) {
+		InfoEntity infoEntity = infoRepository.findById(infoId)
+			.orElseThrow(() -> new InfoException(InfoExceptionMessage.INVALID_INFO_NUMBER));
+		return infoEntity;
+	}
+
+	private void makeUpdateEntity(InfoRequest updateRequest, InfoEntity infoEntity) {
+		infoEntity.update(
+			updateRequest.title(),
+			updateRequest.content(),
+			updateRequest.infoCategory(),
+			updateRequest.imageUrl(),
+			updateRequest.isDisplay()
+		);
+	}
+
+}

--- a/src/test/java/com/example/green/domain/info/controller/InfoControllerTest.java
+++ b/src/test/java/com/example/green/domain/info/controller/InfoControllerTest.java
@@ -1,0 +1,5 @@
+package com.example.green.domain.info.controller;
+
+class InfoControllerTest {
+
+}

--- a/src/test/java/com/example/green/domain/info/domain/InfoEntityTest.java
+++ b/src/test/java/com/example/green/domain/info/domain/InfoEntityTest.java
@@ -88,7 +88,7 @@ class InfoEntityTest {
 		if (value.equals("notValid")) {
 			assertThatThrownBy(() -> createInfo(isDisplay))
 				.isInstanceOf(BusinessException.class)
-				.hasMessageContaining("경로 변수 또는 쿼리 파라미터의 타입이 잘못되었습니다.");
+				.hasMessageContaining("서버에서 본문을 처리할 수 없습니다.");
 		} else {
 			assertThat(createInfo(isDisplay).getIsDisplay()).isEqualTo("N");
 		}

--- a/src/test/java/com/example/green/domain/info/domain/InfoEntityTest.java
+++ b/src/test/java/com/example/green/domain/info/domain/InfoEntityTest.java
@@ -9,18 +9,21 @@ import java.io.Serializable;
 
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
 import org.hibernate.query.sql.spi.NativeQueryImplementor;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import com.example.green.domain.info.domain.vo.InfoCategory;
 import com.example.green.domain.info.exception.InfoException;
 import com.example.green.domain.info.utils.PrefixSequenceIdGenerator;
+import com.example.green.global.error.exception.BusinessException;
 
 /**
  * 정보(Info) 관련 도메인의 단위 테스트를 진행하는 테스트 클래스
+ * - PrefixSequenceIdGenerator 클래스도 Entity 생성 시 사용되므로 함께 테스트
  */
 
 @ExtendWith(MockitoExtension.class)
@@ -29,29 +32,24 @@ class InfoEntityTest {
 	SharedSessionContractImplementor session;
 	@Mock
 	NativeQueryImplementor<String> query;
-	PrefixSequenceIdGenerator generator = new PrefixSequenceIdGenerator();
-	private InfoCategory infoCategory;
 
 	// 테스트 편의용
-	private static InfoEntity createInfo(InfoCategory infoCategory) {
+	private static InfoEntity createInfo(String isDisplay) {
 		return InfoEntity.builder()
 			.title("title")
 			.content("content")
-			.infoCategory(infoCategory)
+			.infoCategory(InfoCategory.CONTENTS)
 			.imageUrl("imageUrl")
-			.isDisplay("Y")
+			.isDisplay(isDisplay)
 			.build();
-	}
-
-	@BeforeEach
-	void setUp() {
-		infoCategory = InfoCategory.PARTICIPANT;
 	}
 
 	@Test
 	void 정보커스텀ID_첫_생성_케이스_테스트() {
 		when(session.createNativeQuery(anyString())).thenReturn(query);
 		when(query.uniqueResult()).thenReturn(null);
+
+		PrefixSequenceIdGenerator generator = new PrefixSequenceIdGenerator();
 
 		Serializable id = generator.generate(session, new Object());
 		assertEquals("P000001", id);
@@ -62,6 +60,8 @@ class InfoEntityTest {
 		when(session.createNativeQuery(anyString())).thenReturn(query);
 		when(query.uniqueResult()).thenReturn("P000042");
 
+		PrefixSequenceIdGenerator generator = new PrefixSequenceIdGenerator();
+
 		Serializable id = generator.generate(session, new Object());
 		assertEquals("P000043", id);
 	}
@@ -71,29 +71,47 @@ class InfoEntityTest {
 		when(session.createNativeQuery(anyString())).thenReturn(query);
 		when(query.uniqueResult()).thenThrow(new RuntimeException("DB Error"));
 
+		PrefixSequenceIdGenerator generator = new PrefixSequenceIdGenerator();
+
 		assertThatThrownBy(() -> generator.generate(session, new Object()))
 			.isInstanceOf(InfoException.class)
 			.hasMessageContaining("정보 ID 생성 중 오류가 발생했습니다.");
 	}
 
+	@ParameterizedTest
+	@ValueSource(strings = {"notValid", "n"})
+	void 전시여부가_YN또는yn가_아니면_예외를_던진다(String value) {
+		//given
+		String isDisplay = value;
+
+		//when & then
+		if (value.equals("notValid")) {
+			assertThatThrownBy(() -> createInfo(isDisplay))
+				.isInstanceOf(BusinessException.class)
+				.hasMessageContaining("경로 변수 또는 쿼리 파라미터의 타입이 잘못되었습니다.");
+		} else {
+			assertThat(createInfo(isDisplay).getIsDisplay()).isEqualTo("N");
+		}
+	}
+
 	@Test
 	void 정보_도메인을_생성한다() {
 		//given & when
-		InfoEntity infoEntity = createInfo(infoCategory);
+		InfoEntity infoEntity = createInfo("Y");
 
 		//then
 		assertThat(infoEntity.getTitle()).isEqualTo("title");
-		assertThat(infoEntity.getInfoCategory().getDescription()).isEqualTo("참여형");
+		assertThat(infoEntity.getInfoCategory().getDescription()).isEqualTo("콘텐츠");
 	}
 
 	@Test
 	void 정보_도메인을_수정한다() {
 		//given
-		InfoEntity infoEntity = createInfo(infoCategory);
+		InfoEntity infoEntity = createInfo("Y");
 
 		//when
 		InfoCategory updateInfoCategory = mock(InfoCategory.class);
-		when(updateInfoCategory.getDescription()).thenReturn("커뮤니티");
+		when(updateInfoCategory.getDescription()).thenReturn("기타");
 
 		infoEntity.update(
 			"updateTitle",
@@ -106,6 +124,7 @@ class InfoEntityTest {
 		// then
 		assertThat(infoEntity.getTitle()).isEqualTo("updateTitle");
 		assertThat(infoEntity.getContent()).isEqualTo("updateContent");
-		assertThat(infoEntity.getInfoCategory().getDescription()).isEqualTo("커뮤니티");
+		assertThat(infoEntity.getInfoCategory().getDescription()).isEqualTo("기타");
 	}
+
 }

--- a/src/test/java/com/example/integration/info/InfoServiceIntTest.java
+++ b/src/test/java/com/example/integration/info/InfoServiceIntTest.java
@@ -10,6 +10,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
 
 import com.example.green.domain.common.service.FileManager;
@@ -35,6 +36,8 @@ class InfoServiceIntTest extends ServiceIntegrationTest {
 	private InfoService infoService;
 	@MockitoSpyBean
 	private FileManager fileManager;
+	@Autowired
+	private JdbcTemplate jdbcTemplate;
 
 	private static InfoRequest createSaveInfoRequest() {
 		return InfoRequest.builder()
@@ -57,8 +60,8 @@ class InfoServiceIntTest extends ServiceIntegrationTest {
 	}
 
 	@AfterEach
-	void cleanUp() {
-		infoRepository.deleteAll();
+	void tearDown() {
+		infoRepository.deleteAllInBatch();
 	}
 
 	@Nested
@@ -69,7 +72,6 @@ class InfoServiceIntTest extends ServiceIntegrationTest {
 
 			@BeforeEach
 			void setup() {
-				// 저장 된 정보가 없을 경우를 대비하여 테스트용 데이터 생성
 				InfoRequest infoRequest = createSaveInfoRequest();
 				infoEntity = infoRepository.save(infoRequest.toEntity());
 			}
@@ -189,6 +191,11 @@ class InfoServiceIntTest extends ServiceIntegrationTest {
 
 		@Nested
 		class 디폴트_Entity_생성하지_않음 {
+			@BeforeEach
+			void cleanUpBefore() {
+				jdbcTemplate.execute("TRUNCATE TABLE INFO");
+			}
+
 			@Test
 			void 정보를_등록한다() {
 				// TODO [리펙토링필요] -> 시큐리티 어노테이션 완성되면 사용자ID(lastModifiedBy) 값이 제대로 반영되는지 확인
@@ -214,7 +221,6 @@ class InfoServiceIntTest extends ServiceIntegrationTest {
 
 		@BeforeEach
 		void setup() {
-			// 저장 된 정보가 없을 경우를 대비하여 테스트용 데이터 생성
 			InfoRequest infoRequest = createSaveInfoRequest();
 			infoEntity = infoRepository.save(infoRequest.toEntity());
 		}

--- a/src/test/java/com/example/integration/info/InfoServiceIntTest.java
+++ b/src/test/java/com/example/integration/info/InfoServiceIntTest.java
@@ -1,0 +1,275 @@
+package com.example.integration.info;
+
+import static org.assertj.core.api.Assertions.*;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
+
+import com.example.green.domain.common.service.FileManager;
+import com.example.green.domain.info.domain.InfoEntity;
+import com.example.green.domain.info.domain.vo.InfoCategory;
+import com.example.green.domain.info.dto.InfoRequest;
+import com.example.green.domain.info.exception.InfoException;
+import com.example.green.domain.info.exception.InfoExceptionMessage;
+import com.example.green.domain.info.repository.InfoRepository;
+import com.example.green.domain.info.service.InfoService;
+import com.example.integration.common.ServiceIntegrationTest;
+
+/**
+ * 정보공유(Info) 관련 비즈니스 계층의 통합 테스트를 진행하는 테스트 클래스
+ * - Repository 단은 별도로 테스트하지 않음 (Hibernate 외부 시스템 사용)
+ * - Service 단 단위테스트는 통합테스트로 대체 (응답값 검증 위주)
+ */
+class InfoServiceIntTest extends ServiceIntegrationTest {
+
+	@Autowired
+	private InfoRepository infoRepository;
+	@Autowired
+	private InfoService infoService;
+	@MockitoSpyBean
+	private FileManager fileManager;
+
+	private static InfoRequest createSaveInfoRequest() {
+		return InfoRequest.builder()
+			.title("title")
+			.content("content")
+			.infoCategory(InfoCategory.CONTENTS)
+			.imageUrl("imageUrl")
+			.isDisplay("Y")
+			.build();
+	}
+
+	private static InfoRequest createUpdateInfoRequest() {
+		return InfoRequest.builder()
+			.title("updateTitle")
+			.content("updateContent")
+			.infoCategory(InfoCategory.ETC)
+			.imageUrl("updateImageUrl")
+			.isDisplay("N")
+			.build();
+	}
+
+	@AfterEach
+	void cleanUp() {
+		infoRepository.deleteAll();
+	}
+
+	@Nested
+	class 관리자 {
+		@Nested
+		class 디폴트_Entity_생성 {
+			private InfoEntity infoEntity;
+
+			@BeforeEach
+			void setup() {
+				// 저장 된 정보가 없을 경우를 대비하여 테스트용 데이터 생성
+				InfoRequest infoRequest = createSaveInfoRequest();
+				infoEntity = infoRepository.save(infoRequest.toEntity());
+			}
+
+			@Test
+			void 정보_목록을_조회한다() {
+				// given
+				int page = 0;
+				int size = 10;
+
+				// when
+				var response = infoService.getInfosForAdmin(page, size);
+
+				// then
+				assertThat(response.content()).isNotEmpty();
+				assertThat(response.page().totalPages()).isGreaterThan(0);
+				// Enum 타입이 String으로 변환되어 반환되는지 확인
+				assertThat(response.content().get(0).infoCategoryName()).isEqualTo(
+					infoEntity.getInfoCategory().getDescription());
+			}
+
+			@Test
+			void 정보_목록을_조회할_때에는_삭제된_정보는_포함되지_않는다() {
+				// given
+				infoEntity.markDeleted();
+				infoRepository.save(infoEntity);
+
+				InfoRequest infoRequest2 = createSaveInfoRequest();
+				infoRepository.save(infoRequest2.toEntity());
+
+				int page = 0;
+				int size = 10;
+
+				// when
+				var response = infoService.getInfosForAdmin(page, size);
+
+				// then
+				assertThat(response.content()).size().isEqualTo(1);
+			}
+
+			@Test
+			void 정보_목록_조회가_등록일을_기준으로_내림차순_정렬로_조회된다() {
+				// given
+				InfoRequest infoRequest2 = createSaveInfoRequest();
+				InfoEntity infoEntity2 = infoRepository.save(infoRequest2.toEntity());
+
+				InfoRequest infoRequest3 = createSaveInfoRequest();
+				InfoEntity infoEntity3 = infoRepository.save(infoRequest3.toEntity());
+
+				int page = 0;
+				int size = 10;
+
+				// when
+				var response = infoService.getInfosForAdmin(page, size);
+
+				// then
+				assertThat(response.content()).hasSize(3);
+				assertThat(response.content().get(0).id()).isEqualTo(infoEntity3.getId());
+				assertThat(response.content().get(1).id()).isEqualTo(infoEntity2.getId());
+			}
+
+			@Test
+			void 정보_상세를_조회한다() {
+				// given
+				String infoId = infoEntity.getId();
+
+				// when
+				var response = infoService.getInfoDetailForAdmin(infoId);
+
+				// then
+				assertThat(response.title()).isEqualTo(infoEntity.getTitle());
+			}
+
+			@ParameterizedTest
+			@ValueSource(strings = {"notExitsId", ""})
+			void 정보_상세를_찾을_수_없다면_예외를_던진다(String infoId) {
+				// TODO [추후작업필요] controller 에서 변수로 받는 id 값 null 처리 해줘야 required = true (서비스까지 넘어오지 못하게)
+				// when & then
+				assertThatThrownBy(() -> infoService.getInfoDetailForAdmin(infoId))
+					.isInstanceOf(InfoException.class)
+					.hasFieldOrPropertyWithValue("exceptionMessage", InfoExceptionMessage.INVALID_INFO_NUMBER);
+			}
+
+			@Test
+			void 정보를_수정한다() {
+				// TODO [리펙토링필요] -> 시큐리티 어노테이션 완성되면 실제 인입되는 ID로 변경 테스트
+				// given
+				InfoRequest updateRequest = createUpdateInfoRequest();
+				Mockito.doNothing().when(fileManager).unUseImage(Mockito.anyString());
+				Mockito.doNothing().when(fileManager).confirmUsingImage(Mockito.anyString());
+
+				// when
+				var response = infoService.updateInfo(infoEntity.getId(), updateRequest);
+
+				// then
+				assertThat(response.title()).isEqualTo(updateRequest.title());
+				assertThat(response.imageurl()).isEqualTo(updateRequest.imageUrl());
+				// assertThat(response.modifiedDate()).isNotEqualTo(infoEntity.getCreatedDate()); // 테스트시 시간차 구현이 어려움
+				//assertThat(response.registerId()).isEqualTo(newLonginId); // 수정자 ID가 제대로 반영이 되었는지
+			}
+
+			@Test
+			void 정보를_삭제한다() {
+				// given
+				String deleteInfoId = infoEntity.getId();
+				Mockito.doNothing().when(fileManager).unUseImage(Mockito.anyString());
+
+				// when
+				infoService.deleteInfo(deleteInfoId);
+
+				// given
+				assertThatThrownBy(() -> infoService.getInfoDetailForAdmin(deleteInfoId))
+					.isInstanceOf(InfoException.class)
+					.hasFieldOrPropertyWithValue("exceptionMessage", InfoExceptionMessage.INVALID_INFO_NUMBER);
+			}
+		}
+
+		@Nested
+		class 디폴트_Entity_생성하지_않음 {
+			@Test
+			void 정보를_등록한다() {
+				// TODO [리펙토링필요] -> 시큐리티 어노테이션 완성되면 사용자ID(lastModifiedBy) 값이 제대로 반영되는지 확인
+				// TODO [확인필요] SpyBean 사용하여 건너띄는 방식으로 FileService 의존성 분리 -> 더 좋은 방법이 있을지
+				// given
+				InfoRequest saveRequest = createSaveInfoRequest();
+				Mockito.doNothing().when(fileManager).confirmUsingImage(Mockito.anyString());
+
+				// when
+				var response = infoService.saveInfo(saveRequest);
+
+				//then
+				assertThat(response.id()).isEqualTo("P000001");
+				assertThat(response.title()).isEqualTo(saveRequest.title());
+				assertThat(response.modifiedDate()).isNotNull(); // 수정일자 확인
+			}
+		}
+	}
+
+	@Nested
+	class 사용자 {
+		private InfoEntity infoEntity;
+
+		@BeforeEach
+		void setup() {
+			// 저장 된 정보가 없을 경우를 대비하여 테스트용 데이터 생성
+			InfoRequest infoRequest = createSaveInfoRequest();
+			infoEntity = infoRepository.save(infoRequest.toEntity());
+		}
+
+		@Test
+		void 정보_목록을_조회한다() {
+
+			// when
+			var response = infoService.getInfosForUser();
+
+			// then
+			assertThat(response.content()).isNotEmpty();
+			assertThat(response.content().get(0).infoCategoryName()).isEqualTo(
+				infoEntity.getInfoCategory().getDescription());
+		}
+
+		@Test
+		void 정보_목록을_조회할_때에는_삭제된_정보는_포함되지_않는다() {
+			// given
+			InfoRequest infoRequest = createUpdateInfoRequest();
+
+			InfoEntity infoEntityToDelete = infoRequest.toEntity();
+			infoEntityToDelete.markDeleted();
+
+			infoRepository.save(infoEntityToDelete);
+
+			// when
+			var response = infoService.getInfosForUser();
+
+			// then
+			assertThat(response.content()).size().isEqualTo(1);
+		}
+
+		@Test
+		void 정보_목록을_조회할_때에는_미전시_정보는_포함되지_않는다() {
+			// given
+			InfoRequest infoRequest = createUpdateInfoRequest();
+			infoRepository.save(infoRequest.toEntity());
+
+			// when
+			var response = infoService.getInfosForUser();
+
+			// then
+			assertThat(response.content()).size().isEqualTo(1);
+		}
+
+		@Test
+		void 정보_상세를_조회한다() {
+			// when
+			var response = infoService.getInfoDetailForUser(infoEntity.getId());
+
+			// then
+			assertThat(response.title()).isEqualTo(infoEntity.getTitle());
+			assertThat(response.infoCategoryName()).isEqualTo(
+				infoEntity.getInfoCategory().getDescription());
+		}
+	}
+}


### PR DESCRIPTION
* Service 통합테스트 작성
* 통합테스트 바탕으로 Service 비즈니스 로직 구현
* Entity 단 null data 방어로직 추가 (지환님 코드 참고 06.30)
* Entity 필드 Category Enum 필드값 변경 (기타 컨텐츠 추가)

## #️⃣ 연관된 이슈

> #56 

## 📝 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
- 정보공유 서비스단 작업 


## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
- 파일 컨텍스트 부분 서비스 통합테스트를 위해 @SpyBean 사용해서 테스트 했는데, 더 좋은 방안 있으면 언제든 환영입니다!
- 등록부분에서 deleteAll 을 해도 데이터베이스가 관리하는 AUTO_INCREMENT가 초기화 되지 않아서 jdbcTemplate을 주입받아서 쿼리로 truncate 해서 초기화 시켰습니다. 더 좋은 테스트 방법 있으면 변경하겠습니다. 
- Paging 부분은 이전에 회의에서 논의하였던 대로 통일된 결과값을 도출하려 wrapper 클래스 만들었습니다. 
현정님 API 명세 기반 : https://round-throat-587.notion.site/API-17b1eb2dd4d18109b249dacac54b685d?p=20b1eb2dd4d1800f92ccc8f92a36b718&pm=s
```
"result": {
    "content": [
      {
        "chlgTitle": "오늘은 따릉이 타는 날",
        "chlgCode": "CH-P-20250602-002",
        "userId": "24061",
        "certificationDate": "2025-08-02",
        "certificationImage": "1_1.png",
        "review": "좋았습니다",
        "pointStatus": "REQUEST"
      }
    ],
    "page": {
      // "pageNumber": 0,
      // "pageSize": 10,
(저는 2개만 노출시켰습니다)
      "totalElements": 1,
      "totalPages": 1
    }
  }
```


[참고]
- 정보공유단은 서비스에서 가공하는 로직이 크게 없어서 단위테스트 생략하고 바로 통합테스트 진행했습니다. 
- Repository 단도 역시 마찬가지로 커스텀 쿼리를 작성하는 부분이 없어서 단위테스트 생략하였습니다. 
- Entity 에는 지환님 #53 코드 리뷰를 바탕으로 null check 추가하였습니다. 
### 📌 PR 진행 시 참고사항
- 리뷰어는 좋은 코드 방향을 제시하되, **수정을 강요하지 않습니다.**
- 좋은 코드를 발견하면 **칭찬과 격려를 아끼지 않습니다.**
- 리뷰는 Reviewer로 지정된 시점 기준으로 **3일 이내**에 진행해 주세요.
- Comment 작성 시 아래 Prefix를 사용해 주세요:
    - `P1`: 꼭 반영해 주세요 (Request Changes) – 이슈나 취약점 관련
    - `P2`: 반영을 고려해 주세요 (Comment) – 개선 의견
    - `P3`: 단순 제안 (Chore)
