### PR TITLE
feat: [#104] 챌린지 참여, 인증 엔티티 생성 (팀, 개인)

### DIFF
--- a/src/main/java/com/example/green/domain/challengecert/entity/BaseChallengeCertification.java
+++ b/src/main/java/com/example/green/domain/challengecert/entity/BaseChallengeCertification.java
@@ -1,0 +1,122 @@
+package com.example.green.domain.challengecert.entity;
+
+import static com.example.green.global.utils.EntityValidator.*;
+
+import java.time.LocalDateTime;
+
+import com.example.green.domain.challengecert.exception.ChallengeCertException;
+import com.example.green.domain.challengecert.exception.ChallengeCertExceptionMessage;
+import com.example.green.domain.common.BaseEntity;
+import com.example.green.domain.member.entity.Member;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.MappedSuperclass;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@MappedSuperclass
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public abstract class BaseChallengeCertification extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member member;
+
+    @Column(length = 500, nullable = false)
+    private String certificationImageUrl;
+
+    @Column(columnDefinition = "TEXT")
+    private String certificationReview;
+
+    @Column(nullable = false)
+    private LocalDateTime certifiedAt;
+
+	/**
+	 * 인증 날짜 (YYYY-MM-DD 형식)
+	 * 하루 한 번 인증 제약조건을 위한 날짜 값
+	 */
+	@Column(nullable = false)
+	private String certifiedDate;
+
+    @Column(nullable = false)
+    private Boolean approved = false;
+
+    private LocalDateTime approvedAt;
+
+    // 하위 클래스를 위한 protected 생성자
+    protected BaseChallengeCertification(
+        Member member,
+        String certificationImageUrl,
+        String certificationReview,
+        LocalDateTime certifiedAt,
+        String certifiedDate
+    ) {
+        this.member = member;
+        this.certificationImageUrl = certificationImageUrl;
+        this.certificationReview = certificationReview;
+        this.certifiedAt = certifiedAt;
+        this.certifiedDate = certifiedDate;
+        this.approved = false;
+    }
+
+    /**
+     * 관리자 승인 처리
+     */
+    public void approve(LocalDateTime approvedAt) {
+        validateNullData(approvedAt, "승인 시각은 필수값입니다.");
+
+        if (this.approved) {
+            throw new ChallengeCertException(ChallengeCertExceptionMessage.CERTIFICATION_ALREADY_APPROVED);
+        }
+        this.approved = true;
+        this.approvedAt = approvedAt;
+    }
+
+    /**
+     * 인증 내용 수정
+     */
+    public void updateCertification(String certificationImageUrl, String certificationReview) {
+        if (this.approved) {
+            throw new ChallengeCertException(ChallengeCertExceptionMessage.CERTIFICATION_ALREADY_APPROVED);
+        }
+
+        validateEmptyString(certificationImageUrl, "인증 이미지는 필수값입니다.");
+        this.certificationImageUrl = certificationImageUrl;
+        this.certificationReview = certificationReview;
+    }
+
+    /**
+     * 승인 가능 여부 확인
+     */
+    public boolean canApprove() {
+        return !this.approved;
+    }
+
+    /**
+     * 수정 가능 여부 확인
+     */
+    public boolean canUpdate() {
+        return !this.approved;
+    }
+
+    protected void validateCertificationData() {
+        validateNullData(member, "회원은 필수값입니다.");
+        validateEmptyString(certificationImageUrl, "인증 이미지는 필수값입니다.");
+        validateNullData(certifiedAt, "인증 시각은 필수값입니다.");
+        validateEmptyString(certifiedDate, "인증 날짜는 필수값입니다.");
+    }
+}

--- a/src/main/java/com/example/green/domain/challengecert/entity/BaseChallengeCertification.java
+++ b/src/main/java/com/example/green/domain/challengecert/entity/BaseChallengeCertification.java
@@ -28,22 +28,22 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 public abstract class BaseChallengeCertification extends BaseEntity {
 
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "member_id", nullable = false)
-    private Member member;
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "member_id", nullable = false)
+	private Member member;
 
-    @Column(length = 500, nullable = false)
-    private String certificationImageUrl;
+	@Column(length = 500, nullable = false)
+	private String certificationImageUrl;
 
-    @Column(columnDefinition = "TEXT")
-    private String certificationReview;
+	@Column(columnDefinition = "TEXT")
+	private String certificationReview;
 
-    @Column(nullable = false)
-    private LocalDateTime certifiedAt;
+	@Column(nullable = false)
+	private LocalDateTime certifiedAt;
 
 	/**
 	 * 인증 날짜 (YYYY-MM-DD 형식)
@@ -52,71 +52,71 @@ public abstract class BaseChallengeCertification extends BaseEntity {
 	@Column(nullable = false)
 	private String certifiedDate;
 
-    @Column(nullable = false)
-    private Boolean approved = false;
+	@Column(nullable = false)
+	private Boolean approved = false;
 
-    private LocalDateTime approvedAt;
+	private LocalDateTime approvedAt;
 
-    // 하위 클래스를 위한 protected 생성자
-    protected BaseChallengeCertification(
-        Member member,
-        String certificationImageUrl,
-        String certificationReview,
-        LocalDateTime certifiedAt,
-        String certifiedDate
-    ) {
-        this.member = member;
-        this.certificationImageUrl = certificationImageUrl;
-        this.certificationReview = certificationReview;
-        this.certifiedAt = certifiedAt;
-        this.certifiedDate = certifiedDate;
-        this.approved = false;
-    }
+	// 하위 클래스를 위한 protected 생성자
+	protected BaseChallengeCertification(
+		Member member,
+		String certificationImageUrl,
+		String certificationReview,
+		LocalDateTime certifiedAt,
+		String certifiedDate
+	) {
+		this.member = member;
+		this.certificationImageUrl = certificationImageUrl;
+		this.certificationReview = certificationReview;
+		this.certifiedAt = certifiedAt;
+		this.certifiedDate = certifiedDate;
+		this.approved = false;
+	}
 
-    /**
-     * 관리자 승인 처리
-     */
-    public void approve(LocalDateTime approvedAt) {
-        validateNullData(approvedAt, "승인 시각은 필수값입니다.");
+	/**
+	 * 관리자 승인 처리
+	 */
+	public void approve(LocalDateTime approvedAt) {
+		validateNullData(approvedAt, "승인 시각은 필수값입니다.");
 
-        if (this.approved) {
-            throw new ChallengeCertException(ChallengeCertExceptionMessage.CERTIFICATION_ALREADY_APPROVED);
-        }
-        this.approved = true;
-        this.approvedAt = approvedAt;
-    }
+		if (this.approved) {
+			throw new ChallengeCertException(ChallengeCertExceptionMessage.CERTIFICATION_ALREADY_APPROVED);
+		}
+		this.approved = true;
+		this.approvedAt = approvedAt;
+	}
 
-    /**
-     * 인증 내용 수정
-     */
-    public void updateCertification(String certificationImageUrl, String certificationReview) {
-        if (this.approved) {
-            throw new ChallengeCertException(ChallengeCertExceptionMessage.CERTIFICATION_ALREADY_APPROVED);
-        }
+	/**
+	 * 인증 내용 수정
+	 */
+	public void updateCertification(String certificationImageUrl, String certificationReview) {
+		if (this.approved) {
+			throw new ChallengeCertException(ChallengeCertExceptionMessage.CERTIFICATION_ALREADY_APPROVED);
+		}
 
-        validateEmptyString(certificationImageUrl, "인증 이미지는 필수값입니다.");
-        this.certificationImageUrl = certificationImageUrl;
-        this.certificationReview = certificationReview;
-    }
+		validateEmptyString(certificationImageUrl, "인증 이미지는 필수값입니다.");
+		this.certificationImageUrl = certificationImageUrl;
+		this.certificationReview = certificationReview;
+	}
 
-    /**
-     * 승인 가능 여부 확인
-     */
-    public boolean canApprove() {
-        return !this.approved;
-    }
+	/**
+	 * 승인 가능 여부 확인
+	 */
+	public boolean canApprove() {
+		return !this.approved;
+	}
 
-    /**
-     * 수정 가능 여부 확인
-     */
-    public boolean canUpdate() {
-        return !this.approved;
-    }
+	/**
+	 * 수정 가능 여부 확인
+	 */
+	public boolean canUpdate() {
+		return !this.approved;
+	}
 
-    protected void validateCertificationData() {
-        validateNullData(member, "회원은 필수값입니다.");
-        validateEmptyString(certificationImageUrl, "인증 이미지는 필수값입니다.");
-        validateNullData(certifiedAt, "인증 시각은 필수값입니다.");
-        validateEmptyString(certifiedDate, "인증 날짜는 필수값입니다.");
-    }
+	protected void validateCertificationData() {
+		validateNullData(member, "회원은 필수값입니다.");
+		validateEmptyString(certificationImageUrl, "인증 이미지는 필수값입니다.");
+		validateNullData(certifiedAt, "인증 시각은 필수값입니다.");
+		validateEmptyString(certifiedDate, "인증 날짜는 필수값입니다.");
+	}
 }

--- a/src/main/java/com/example/green/domain/challengecert/entity/BaseChallengeParticipation.java
+++ b/src/main/java/com/example/green/domain/challengecert/entity/BaseChallengeParticipation.java
@@ -1,7 +1,5 @@
 package com.example.green.domain.challengecert.entity;
 
-import static com.example.green.global.utils.EntityValidator.*;
-
 import java.time.LocalDateTime;
 
 import com.example.green.domain.common.BaseEntity;
@@ -44,10 +42,5 @@ public abstract class BaseChallengeParticipation extends BaseEntity {
 	) {
 		this.member = member;
 		this.participatedAt = participatedAt;
-	}
-
-	protected void validateParticipation() {
-		validateNullData(member, "회원은 필수값입니다.");
-		validateNullData(participatedAt, "참여 시각은 필수값입니다.");
 	}
 }

--- a/src/main/java/com/example/green/domain/challengecert/entity/BaseChallengeParticipation.java
+++ b/src/main/java/com/example/green/domain/challengecert/entity/BaseChallengeParticipation.java
@@ -26,28 +26,28 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 public abstract class BaseChallengeParticipation extends BaseEntity {
 
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "member_id", nullable = false)
-    private Member member;
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "member_id", nullable = false)
+	private Member member;
 
-    @Column(nullable = false)
-    private LocalDateTime participatedAt;
+	@Column(nullable = false)
+	private LocalDateTime participatedAt;
 
-    // 하위 클래스를 위한 protected 생성자
-    protected BaseChallengeParticipation(
-        Member member,
-        LocalDateTime participatedAt
-    ) {
-        this.member = member;
-        this.participatedAt = participatedAt;
-    }
+	// 하위 클래스를 위한 protected 생성자
+	protected BaseChallengeParticipation(
+		Member member,
+		LocalDateTime participatedAt
+	) {
+		this.member = member;
+		this.participatedAt = participatedAt;
+	}
 
-    protected void validateParticipation() {
-        validateNullData(member, "회원은 필수값입니다.");
-        validateNullData(participatedAt, "참여 시각은 필수값입니다.");
-    }
+	protected void validateParticipation() {
+		validateNullData(member, "회원은 필수값입니다.");
+		validateNullData(participatedAt, "참여 시각은 필수값입니다.");
+	}
 }

--- a/src/main/java/com/example/green/domain/challengecert/entity/BaseChallengeParticipation.java
+++ b/src/main/java/com/example/green/domain/challengecert/entity/BaseChallengeParticipation.java
@@ -1,0 +1,53 @@
+package com.example.green.domain.challengecert.entity;
+
+import static com.example.green.global.utils.EntityValidator.*;
+
+import java.time.LocalDateTime;
+
+import com.example.green.domain.common.BaseEntity;
+import com.example.green.domain.member.entity.Member;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.MappedSuperclass;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@MappedSuperclass
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public abstract class BaseChallengeParticipation extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member member;
+
+    @Column(nullable = false)
+    private LocalDateTime participatedAt;
+
+    // 하위 클래스를 위한 protected 생성자
+    protected BaseChallengeParticipation(
+        Member member,
+        LocalDateTime participatedAt
+    ) {
+        this.member = member;
+        this.participatedAt = participatedAt;
+    }
+
+    protected void validateParticipation() {
+        validateNullData(member, "회원은 필수값입니다.");
+        validateNullData(participatedAt, "참여 시각은 필수값입니다.");
+    }
+}

--- a/src/main/java/com/example/green/domain/challengecert/entity/PersonalChallengeCertification.java
+++ b/src/main/java/com/example/green/domain/challengecert/entity/PersonalChallengeCertification.java
@@ -1,0 +1,77 @@
+package com.example.green.domain.challengecert.entity;
+
+import static com.example.green.global.utils.EntityValidator.*;
+
+import java.time.LocalDateTime;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.Index;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * 개인 챌린지 인증 엔티티
+ */
+@Entity
+@Table(
+	indexes = {
+		@Index(name = "idx_personal_cert_participation", columnList = "participation_id"),
+		@Index(name = "idx_personal_cert_date", columnList = "certified_at"),
+		@Index(name = "idx_personal_cert_member", columnList = "member_id")
+	},
+	uniqueConstraints = {
+		@UniqueConstraint(
+			name = "uk_personal_cert_once_per_day",
+			columnNames = {"participation_id", "certified_date"})
+	}
+)
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class PersonalChallengeCertification extends BaseChallengeCertification {
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "participation_id", nullable = false)
+	private PersonalChallengeParticipation participation;
+
+	public static PersonalChallengeCertification create(
+		PersonalChallengeParticipation participation,
+		String certificationImageUrl,
+		String certificationReview,
+		LocalDateTime certifiedAt,
+		String certifiedDate
+	) {
+		// 필수 값 validate
+		validateNullData(participation, "챌린지 참여 정보는 필수값입니다.");
+		validateEmptyString(certificationImageUrl, "인증 이미지는 필수값입니다.");
+		validateNullData(certifiedAt, "인증 시각은 필수값입니다.");
+		validateEmptyString(certifiedDate, "인증 날짜는 필수값입니다.");
+
+		return new PersonalChallengeCertification(
+			participation,
+			certificationImageUrl,
+			certificationReview,
+			certifiedAt,
+			certifiedDate
+		);
+	}
+
+	private PersonalChallengeCertification(
+		PersonalChallengeParticipation participation,
+		String certificationImageUrl,
+		String certificationReview,
+		LocalDateTime certifiedAt,
+		String certifiedDate
+	) {
+		super(participation.getMember(), certificationImageUrl, certificationReview, certifiedAt, certifiedDate);
+		this.participation = participation;
+		validateCertificationData();
+	}
+}

--- a/src/main/java/com/example/green/domain/challengecert/entity/PersonalChallengeParticipation.java
+++ b/src/main/java/com/example/green/domain/challengecert/entity/PersonalChallengeParticipation.java
@@ -1,0 +1,70 @@
+package com.example.green.domain.challengecert.entity;
+
+import static com.example.green.global.utils.EntityValidator.*;
+
+import java.time.LocalDateTime;
+
+import com.example.green.domain.challenge.entity.PersonalChallenge;
+import com.example.green.domain.member.entity.Member;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.Index;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * 개인 챌린지 참여 엔티티
+ */
+@Entity
+@Table(
+	indexes = {
+		@Index(name = "idx_personal_participation_challenge", columnList = "personal_challenge_id"),
+		@Index(name = "idx_personal_participation_member", columnList = "member_id")
+	},
+	uniqueConstraints = {
+		@UniqueConstraint(
+			name = "uk_personal_participation_challenge_member",
+			columnNames = {"personal_challenge_id", "member_id"})}
+)
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class PersonalChallengeParticipation extends BaseChallengeParticipation {
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "personal_challenge_id", nullable = false)
+	private PersonalChallenge personalChallenge;
+
+	public static PersonalChallengeParticipation create(
+		PersonalChallenge personalChallenge,
+		Member member,
+		LocalDateTime participatedAt
+	) {
+		// 필수 값 validate
+		validateNullData(personalChallenge, "개인 챌린지는 필수값입니다.");
+		validateNullData(member, "회원은 필수값입니다.");
+		validateNullData(participatedAt, "참여 시각은 필수값입니다.");
+
+		return new PersonalChallengeParticipation(
+			personalChallenge,
+			member,
+			participatedAt
+		);
+	}
+
+	private PersonalChallengeParticipation(
+		PersonalChallenge personalChallenge,
+		Member member,
+		LocalDateTime participatedAt
+	) {
+		super(member, participatedAt);
+		this.personalChallenge = personalChallenge;
+	}
+}

--- a/src/main/java/com/example/green/domain/challengecert/entity/TeamChallengeCertification.java
+++ b/src/main/java/com/example/green/domain/challengecert/entity/TeamChallengeCertification.java
@@ -1,0 +1,74 @@
+package com.example.green.domain.challengecert.entity;
+
+import static com.example.green.global.utils.EntityValidator.*;
+
+import java.time.LocalDateTime;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.Index;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(
+	indexes = {
+		@Index(name = "idx_team_cert_participation", columnList = "participation_id"),
+		@Index(name = "idx_team_cert_date", columnList = "certified_at"),
+		@Index(name = "idx_team_cert_member", columnList = "member_id")
+	},
+	uniqueConstraints = {
+		@UniqueConstraint(
+			name = "uk_team_cert_once_per_day",
+			columnNames = {"participation_id", "certified_date"})
+	}
+)
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class TeamChallengeCertification extends BaseChallengeCertification {
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "participation_id", nullable = false)
+	private TeamChallengeParticipation participation;
+
+	public static TeamChallengeCertification create(
+		TeamChallengeParticipation participation,
+		String certificationImageUrl,
+		String certificationReview,
+		LocalDateTime certifiedAt,
+		String certifiedDate
+	) {
+		// 필수 값 validate
+		validateNullData(participation, "챌린지 참여 정보는 필수값입니다.");
+		validateEmptyString(certificationImageUrl, "인증 이미지는 필수값입니다.");
+		validateNullData(certifiedAt, "인증 시각은 필수값입니다.");
+		validateEmptyString(certifiedDate, "인증 날짜는 필수값입니다.");
+
+		return new TeamChallengeCertification(
+			participation,
+			certificationImageUrl,
+			certificationReview,
+			certifiedAt,
+			certifiedDate
+		);
+	}
+
+	private TeamChallengeCertification(
+		TeamChallengeParticipation participation,
+		String certificationImageUrl,
+		String certificationReview,
+		LocalDateTime certifiedAt,
+		String certifiedDate
+	) {
+		super(participation.getMember(), certificationImageUrl, certificationReview, certifiedAt, certifiedDate);
+		this.participation = participation;
+		validateCertificationData();
+	}
+}

--- a/src/main/java/com/example/green/domain/challengecert/entity/TeamChallengeParticipation.java
+++ b/src/main/java/com/example/green/domain/challengecert/entity/TeamChallengeParticipation.java
@@ -1,0 +1,120 @@
+package com.example.green.domain.challengecert.entity;
+
+import static com.example.green.global.utils.EntityValidator.*;
+
+import java.time.LocalDateTime;
+
+import com.example.green.domain.challenge.entity.TeamChallengeGroup;
+import com.example.green.domain.challengecert.entity.enums.GroupRoleType;
+import com.example.green.domain.member.entity.Member;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.Index;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(
+	indexes = {
+		@Index(name = "idx_team_participation_group", columnList = "team_challenge_group_id"),
+		@Index(name = "idx_team_participation_member", columnList = "member_id")
+	},
+	uniqueConstraints = {
+		@UniqueConstraint(
+			name = "uk_team_participation_group_member",
+			columnNames = {"team_challenge_group_id", "member_id"})
+	}
+)
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class TeamChallengeParticipation extends BaseChallengeParticipation {
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "team_challenge_group_id", nullable = false)
+	private TeamChallengeGroup teamChallengeGroup;
+
+	@Enumerated(EnumType.STRING)
+	@Column(nullable = false, length = 20)
+	private GroupRoleType groupRoleType;
+
+	/**
+	 * 팀 리더로 참여
+	 */
+	public static TeamChallengeParticipation createLeader(
+		TeamChallengeGroup teamChallengeGroup,
+		Member member,
+		LocalDateTime participatedAt
+	) {
+		return create(
+			teamChallengeGroup,
+			member,
+			GroupRoleType.LEADER,
+			participatedAt
+		);
+	}
+
+	/**
+	 * 팀원으로 참여
+	 */
+	public static TeamChallengeParticipation createMember(
+		TeamChallengeGroup teamChallengeGroup,
+		Member member,
+		LocalDateTime participatedAt
+	) {
+		return create(
+			teamChallengeGroup,
+			member,
+			GroupRoleType.MEMBER,
+			participatedAt
+		);
+	}
+
+	private static TeamChallengeParticipation create(
+		TeamChallengeGroup teamChallengeGroup,
+		Member member,
+		GroupRoleType groupRoleType,
+		LocalDateTime participatedAt
+	) {
+		// 필수 값 validate
+		validateNullData(teamChallengeGroup, "팀 챌린지 그룹은 필수값입니다.");
+		validateNullData(member, "회원은 필수값입니다.");
+		validateNullData(groupRoleType, "팀 내 역할은 필수값입니다.");
+		validateNullData(participatedAt, "참여 시각은 필수값입니다.");
+
+		return new TeamChallengeParticipation(
+			teamChallengeGroup,
+			member,
+			groupRoleType,
+			participatedAt
+		);
+	}
+
+	private TeamChallengeParticipation(
+		TeamChallengeGroup teamChallengeGroup,
+		Member member,
+		GroupRoleType groupRoleType,
+		LocalDateTime participatedAt
+	) {
+		super(member, participatedAt);
+		this.teamChallengeGroup = teamChallengeGroup;
+		this.groupRoleType = groupRoleType;
+	}
+
+	/**
+	 * 팀 리더인지 확인
+	 */
+	public boolean isLeader() {
+		return GroupRoleType.LEADER.equals(this.groupRoleType);
+	}
+}

--- a/src/main/java/com/example/green/domain/challengecert/entity/enums/GroupRoleType.java
+++ b/src/main/java/com/example/green/domain/challengecert/entity/enums/GroupRoleType.java
@@ -1,0 +1,14 @@
+package com.example.green.domain.challengecert.entity.enums;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum GroupRoleType {
+
+	LEADER("팀 리더"),
+	MEMBER("팀원");
+
+	private final String description;
+}

--- a/src/main/java/com/example/green/domain/challengecert/exception/ChallengeCertException.java
+++ b/src/main/java/com/example/green/domain/challengecert/exception/ChallengeCertException.java
@@ -1,0 +1,11 @@
+package com.example.green.domain.challengecert.exception;
+
+import com.example.green.global.error.exception.BusinessException;
+import com.example.green.global.error.exception.ExceptionMessage;
+
+public class ChallengeCertException extends BusinessException {
+
+	public ChallengeCertException(ExceptionMessage exceptionMessage) {
+		super(exceptionMessage);
+	}
+}

--- a/src/main/java/com/example/green/domain/challengecert/exception/ChallengeCertExceptionMessage.java
+++ b/src/main/java/com/example/green/domain/challengecert/exception/ChallengeCertExceptionMessage.java
@@ -1,0 +1,22 @@
+package com.example.green.domain.challengecert.exception;
+
+import org.springframework.http.HttpStatus;
+
+import com.example.green.global.error.exception.ExceptionMessage;
+
+import lombok.Getter;
+
+@Getter
+public enum ChallengeCertExceptionMessage implements ExceptionMessage {
+
+	INVALID_MEMBER_SEQUENCE(HttpStatus.BAD_REQUEST, "멤버 가입 순서는 1 이상이어야 하며, 일반 멤버는 1번이 될 수 없습니다."),
+	CERTIFICATION_ALREADY_APPROVED(HttpStatus.BAD_REQUEST, "이미 승인된 인증입니다.");
+
+	private final HttpStatus httpStatus;
+	private final String message;
+
+	ChallengeCertExceptionMessage(HttpStatus httpStatus, String message) {
+		this.httpStatus = httpStatus;
+		this.message = message;
+	}
+}

--- a/src/test/java/com/example/green/domain/challengecert/entity/PersonalChallengeCertificationTest.java
+++ b/src/test/java/com/example/green/domain/challengecert/entity/PersonalChallengeCertificationTest.java
@@ -1,0 +1,209 @@
+package com.example.green.domain.challengecert.entity;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import com.example.green.domain.challenge.entity.PersonalChallenge;
+import com.example.green.domain.challenge.enums.ChallengeStatus;
+import com.example.green.domain.challenge.enums.ChallengeType;
+import com.example.green.domain.challenge.utils.ChallengeCodeGenerator;
+import com.example.green.domain.member.entity.Member;
+import com.example.green.domain.point.entity.vo.PointAmount;
+import com.example.green.global.error.exception.BusinessException;
+
+/**
+ * PersonalChallengeCertification 테스트
+ */
+class PersonalChallengeCertificationTest {
+
+	private PersonalChallengeCertification certification;
+	private PersonalChallengeParticipation participation;
+	private PersonalChallenge personalChallenge;
+	private Member member;
+	private LocalDateTime now;
+
+	@BeforeEach
+	void setUp() {
+		now = LocalDateTime.now();
+
+		// 테스트용 Member 객체 생성
+		member = Member.create("test", "테스트유저", "test@example.com");
+
+		// 테스트용 PersonalChallenge 생성
+		personalChallenge = PersonalChallenge.create(
+			ChallengeCodeGenerator.generate(ChallengeType.PERSONAL, now),
+			"개인 챌린지",
+			ChallengeStatus.PROCEEDING,
+			PointAmount.of(BigDecimal.valueOf(1000)),
+			now.minusDays(1),
+			now.plusDays(7),
+			"challenge-image.jpg",
+			"챌린지 설명"
+		);
+
+		// 테스트용 PersonalChallengeParticipation 생성
+		participation = PersonalChallengeParticipation.create(
+			personalChallenge,
+			member,
+			now.minusHours(2)
+		);
+
+		// 테스트용 PersonalChallengeCertification 생성
+		certification = PersonalChallengeCertification.create(
+			participation,
+			"https://example.com/cert-image.jpg",
+			"인증 후기입니다.",
+			now.minusHours(1),
+			"2025-01-09"
+		);
+	}
+
+	@Test
+	void create_메서드로_개인_챌린지_인증을_생성할_수_있다() {
+		// given
+		String imageUrl = "https://example.com/new-cert.jpg";
+		String review = "새로운 인증 후기";
+		LocalDateTime certifiedAt = now.minusMinutes(30);
+		String certifiedDate = "2025-01-10";
+
+		// when
+		PersonalChallengeCertification newCertification = PersonalChallengeCertification.create(
+			participation,
+			imageUrl,
+			review,
+			certifiedAt,
+			certifiedDate
+		);
+
+		// then
+		assertThat(newCertification.getParticipation()).isEqualTo(participation);
+		assertThat(newCertification.getMember()).isEqualTo(member);
+		assertThat(newCertification.getCertificationImageUrl()).isEqualTo(imageUrl);
+		assertThat(newCertification.getCertificationReview()).isEqualTo(review);
+		assertThat(newCertification.getCertifiedAt()).isEqualTo(certifiedAt);
+		assertThat(newCertification.getCertifiedDate()).isEqualTo(certifiedDate);
+		assertThat(newCertification.getApproved()).isFalse();
+		assertThat(newCertification.getApprovedAt()).isNull();
+	}
+
+	@Test
+	void 참여_정보가_null이면_예외가_발생한다() {
+		// when & then
+		assertThatThrownBy(() -> PersonalChallengeCertification.create(
+			null,
+			"https://example.com/image.jpg",
+			"후기",
+			now,
+			"2025-01-09"
+		))
+			.isInstanceOf(BusinessException.class);
+
+	}
+
+	@Test
+	void 인증_이미지_URL이_null이거나_빈_문자열이면_예외가_발생한다() {
+		// when & then
+		assertThatThrownBy(() -> PersonalChallengeCertification.create(
+			participation,
+			null,
+			"후기",
+			now,
+			"2025-01-09"
+		))
+			.isInstanceOf(BusinessException.class);
+
+		assertThatThrownBy(() -> PersonalChallengeCertification.create(
+			participation,
+			"",
+			"후기",
+			now,
+			"2025-01-09"
+		))
+			.isInstanceOf(BusinessException.class);
+
+	}
+
+	@Test
+	void 인증_시각이_null이면_예외가_발생한다() {
+		// when & then
+		assertThatThrownBy(() -> PersonalChallengeCertification.create(
+			participation,
+			"https://example.com/image.jpg",
+			"후기",
+			null,
+			"2025-01-09"
+		))
+			.isInstanceOf(BusinessException.class);
+
+	}
+
+	@Test
+	void 인증_날짜가_null이거나_빈_문자열이면_예외가_발생한다() {
+		// when & then
+		assertThatThrownBy(() -> PersonalChallengeCertification.create(
+			participation,
+			"https://example.com/image.jpg",
+			"후기",
+			now,
+			null
+		))
+			.isInstanceOf(BusinessException.class);
+
+		assertThatThrownBy(() -> PersonalChallengeCertification.create(
+			participation,
+			"https://example.com/image.jpg",
+			"후기",
+			now,
+			""
+		))
+			.isInstanceOf(BusinessException.class);
+
+	}
+
+	@Test
+	void 인증_후기는_null이어도_된다() {
+		// when & then
+		assertDoesNotThrow(() -> PersonalChallengeCertification.create(
+			participation,
+			"https://example.com/image.jpg",
+			null,
+			now,
+			"2025-01-09"
+		));
+	}
+
+	@Test
+	void 인증을_승인할_수_있다() {
+		// given
+		LocalDateTime approveTime = now;
+
+		// when
+		certification.approve(approveTime);
+
+		// then
+		assertThat(certification.getApproved()).isTrue();
+		assertThat(certification.getApprovedAt()).isEqualTo(approveTime);
+		assertThat(certification.canApprove()).isFalse();
+		assertThat(certification.canUpdate()).isFalse();
+	}
+
+	@Test
+	void 미승인_상태에서_인증_내용을_수정할_수_있다() {
+		// given
+		String newImageUrl = "https://example.com/updated-image.jpg";
+		String newReview = "수정된 후기입니다.";
+
+		// when
+		certification.updateCertification(newImageUrl, newReview);
+
+		// then
+		assertThat(certification.getCertificationImageUrl()).isEqualTo(newImageUrl);
+		assertThat(certification.getCertificationReview()).isEqualTo(newReview);
+	}
+}

--- a/src/test/java/com/example/green/domain/challengecert/entity/PersonalChallengeParticipationTest.java
+++ b/src/test/java/com/example/green/domain/challengecert/entity/PersonalChallengeParticipationTest.java
@@ -1,0 +1,108 @@
+package com.example.green.domain.challengecert.entity;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import com.example.green.domain.challenge.entity.PersonalChallenge;
+import com.example.green.domain.challenge.enums.ChallengeStatus;
+import com.example.green.domain.challenge.enums.ChallengeType;
+import com.example.green.domain.challenge.utils.ChallengeCodeGenerator;
+import com.example.green.domain.member.entity.Member;
+import com.example.green.domain.point.entity.vo.PointAmount;
+import com.example.green.global.error.exception.BusinessException;
+
+/**
+ * PersonalChallengeParticipation 테스트
+ */
+class PersonalChallengeParticipationTest {
+
+	private PersonalChallengeParticipation participation;
+	private PersonalChallenge personalChallenge;
+	private Member member;
+	private LocalDateTime now;
+
+	@BeforeEach
+	void setUp() {
+		now = LocalDateTime.now();
+
+		// 테스트용 Member 객체 생성
+		member = Member.create("google 123456789", "테스트유저", "test@example.com");
+
+		// 테스트용 PersonalChallenge 생성
+		personalChallenge = PersonalChallenge.create(
+			ChallengeCodeGenerator.generate(ChallengeType.PERSONAL, now),
+			"개인 챌린지",
+			ChallengeStatus.PROCEEDING,
+			PointAmount.of(BigDecimal.valueOf(1000)),
+			now.minusDays(1),
+			now.plusDays(7),
+			"challenge-image.jpg",
+			"챌린지 설명"
+		);
+
+		// 테스트용 PersonalChallengeParticipation 생성
+		participation = PersonalChallengeParticipation.create(
+			personalChallenge,
+			member,
+			now.minusHours(1)
+		);
+	}
+
+	@Test
+	void create_메서드로_개인_챌린지_참여를_생성할_수_있다() {
+		// given
+		LocalDateTime participatedAt = now.minusMinutes(30);
+
+		// when
+		PersonalChallengeParticipation newParticipation = PersonalChallengeParticipation.create(
+			personalChallenge,
+			member,
+			participatedAt
+		);
+
+		// then
+		assertThat(newParticipation.getPersonalChallenge()).isEqualTo(personalChallenge);
+		assertThat(newParticipation.getMember()).isEqualTo(member);
+		assertThat(newParticipation.getParticipatedAt()).isEqualTo(participatedAt);
+	}
+
+	@Test
+	void 개인_챌린지가_null이면_예외가_발생한다() {
+		// when & then
+		assertThatThrownBy(() -> PersonalChallengeParticipation.create(
+			null,
+			member,
+			now
+		))
+			.isInstanceOf(BusinessException.class);
+	}
+
+	@Test
+	void 회원이_null이면_예외가_발생한다() {
+		// when & then
+		assertThatThrownBy(() -> PersonalChallengeParticipation.create(
+			personalChallenge,
+			null,
+			now
+		))
+			.isInstanceOf(BusinessException.class);
+
+	}
+
+	@Test
+	void 참여_시각이_null이면_예외가_발생한다() {
+		// when & then
+		assertThatThrownBy(() -> PersonalChallengeParticipation.create(
+			personalChallenge,
+			member,
+			null
+		))
+			.isInstanceOf(BusinessException.class);
+
+	}
+}

--- a/src/test/java/com/example/green/domain/challengecert/entity/TeamChallengeCertificationTest.java
+++ b/src/test/java/com/example/green/domain/challengecert/entity/TeamChallengeCertificationTest.java
@@ -1,0 +1,228 @@
+package com.example.green.domain.challengecert.entity;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import com.example.green.domain.challenge.entity.TeamChallenge;
+import com.example.green.domain.challenge.entity.TeamChallengeGroup;
+import com.example.green.domain.challenge.enums.ChallengeStatus;
+import com.example.green.domain.challenge.enums.ChallengeType;
+import com.example.green.domain.challenge.enums.GroupStatus;
+import com.example.green.domain.challenge.utils.ChallengeCodeGenerator;
+import com.example.green.domain.member.entity.Member;
+import com.example.green.domain.point.entity.vo.PointAmount;
+import com.example.green.global.error.exception.BusinessException;
+
+/**
+ * TeamChallengeCertification 테스트
+ */
+class TeamChallengeCertificationTest {
+
+	private TeamChallengeCertification certification;
+	private TeamChallengeParticipation participation;
+	private TeamChallengeGroup teamChallengeGroup;
+	private TeamChallenge teamChallenge;
+	private Member member;
+	private LocalDateTime now;
+
+	@BeforeEach
+	void setUp() {
+		now = LocalDateTime.now();
+
+		// 테스트용 Member 객체 생성
+		member = Member.create("google 123456789", "테스트유저", "test@example.com");
+
+		// 테스트용 TeamChallenge 생성
+		teamChallenge = TeamChallenge.create(
+			ChallengeCodeGenerator.generate(ChallengeType.TEAM, now),
+			"팀 챌린지",
+			ChallengeStatus.PROCEEDING,
+			PointAmount.of(BigDecimal.valueOf(2000)),
+			now.minusDays(1),
+			now.plusDays(7),
+			5,
+			"challenge-image.jpg",
+			"팀 챌린지 설명"
+		);
+
+		// 테스트용 TeamChallengeGroup 생성
+		teamChallengeGroup = TeamChallengeGroup.create(
+			"테스트 그룹",
+			GroupStatus.PROCEEDING,
+			now.minusHours(2),
+			now.plusDays(6),
+			10,
+			"서울시 강남구",
+			"테스트 그룹 설명",
+			"https://openchat.example.com"
+		);
+
+		// 팀 챌린지에 그룹 추가
+		teamChallenge.addChallengeGroup(teamChallengeGroup);
+
+		// 테스트용 TeamChallengeParticipation 생성 (멤버로 참여)
+		participation = TeamChallengeParticipation.createMember(
+			teamChallengeGroup,
+			member,
+			now.minusHours(1)
+		);
+
+		// 테스트용 TeamChallengeCertification 생성
+		certification = TeamChallengeCertification.create(
+			participation,
+			"https://example.com/team-cert-image.jpg",
+			"팀 챌린지 인증 후기입니다.",
+			now.minusMinutes(30),
+			"2025-01-09"
+		);
+	}
+
+	@Test
+	void create_메서드로_팀_챌린지_인증을_생성할_수_있다() {
+		// given
+		String imageUrl = "https://example.com/new-team-cert.jpg";
+		String review = "새로운 팀 인증 후기";
+		LocalDateTime certifiedAt = now.minusMinutes(15);
+		String certifiedDate = "2025-01-10";
+
+		// when
+		TeamChallengeCertification newCertification = TeamChallengeCertification.create(
+			participation,
+			imageUrl,
+			review,
+			certifiedAt,
+			certifiedDate
+		);
+
+		// then
+		assertThat(newCertification.getParticipation()).isEqualTo(participation);
+		assertThat(newCertification.getMember()).isEqualTo(member);
+		assertThat(newCertification.getCertificationImageUrl()).isEqualTo(imageUrl);
+		assertThat(newCertification.getCertificationReview()).isEqualTo(review);
+		assertThat(newCertification.getCertifiedAt()).isEqualTo(certifiedAt);
+		assertThat(newCertification.getCertifiedDate()).isEqualTo(certifiedDate);
+		assertThat(newCertification.getApproved()).isFalse();
+		assertThat(newCertification.getApprovedAt()).isNull();
+	}
+
+	@Test
+	void 참여_정보가_null이면_예외가_발생한다() {
+		// when & then
+		assertThatThrownBy(() -> TeamChallengeCertification.create(
+			null,
+			"https://example.com/image.jpg",
+			"후기",
+			now,
+			"2025-01-09"
+		))
+			.isInstanceOf(BusinessException.class);
+
+	}
+
+	@Test
+	void 인증_이미지_URL이_null이거나_빈_문자열이면_예외가_발생한다() {
+		// when & then
+		assertThatThrownBy(() -> TeamChallengeCertification.create(
+			participation,
+			null,
+			"후기",
+			now,
+			"2025-01-09"
+		))
+			.isInstanceOf(BusinessException.class);
+
+		assertThatThrownBy(() -> TeamChallengeCertification.create(
+			participation,
+			"",
+			"후기",
+			now,
+			"2025-01-09"
+		))
+			.isInstanceOf(BusinessException.class);
+
+	}
+
+	@Test
+	void 인증_시각이_null이면_예외가_발생한다() {
+		// when & then
+		assertThatThrownBy(() -> TeamChallengeCertification.create(
+			participation,
+			"https://example.com/image.jpg",
+			"후기",
+			null,
+			"2025-01-09"
+		))
+			.isInstanceOf(BusinessException.class);
+
+	}
+
+	@Test
+	void 인증_날짜가_null이거나_빈_문자열이면_예외가_발생한다() {
+		// when & then
+		assertThatThrownBy(() -> TeamChallengeCertification.create(
+			participation,
+			"https://example.com/image.jpg",
+			"후기",
+			now,
+			null
+		))
+			.isInstanceOf(BusinessException.class);
+
+		assertThatThrownBy(() -> TeamChallengeCertification.create(
+			participation,
+			"https://example.com/image.jpg",
+			"후기",
+			now,
+			""
+		))
+			.isInstanceOf(BusinessException.class);
+
+	}
+
+	@Test
+	void 인증_후기는_null이어도_된다() {
+		// when & then
+		assertDoesNotThrow(() -> TeamChallengeCertification.create(
+			participation,
+			"https://example.com/image.jpg",
+			null,
+			now,
+			"2025-01-09"
+		));
+	}
+
+	@Test
+	void 인증을_승인할_수_있다() {
+		// given
+		LocalDateTime approveTime = now;
+
+		// when
+		certification.approve(approveTime);
+
+		// then
+		assertThat(certification.getApproved()).isTrue();
+		assertThat(certification.getApprovedAt()).isEqualTo(approveTime);
+		assertThat(certification.canApprove()).isFalse();
+		assertThat(certification.canUpdate()).isFalse();
+	}
+
+	@Test
+	void 미승인_상태에서_인증_내용을_수정할_수_있다() {
+		// given
+		String newImageUrl = "https://example.com/updated-team-image.jpg";
+		String newReview = "수정된 팀 후기입니다.";
+
+		// when
+		certification.updateCertification(newImageUrl, newReview);
+
+		// then
+		assertThat(certification.getCertificationImageUrl()).isEqualTo(newImageUrl);
+		assertThat(certification.getCertificationReview()).isEqualTo(newReview);
+	}
+}

--- a/src/test/java/com/example/green/domain/challengecert/entity/TeamChallengeParticipationTest.java
+++ b/src/test/java/com/example/green/domain/challengecert/entity/TeamChallengeParticipationTest.java
@@ -1,0 +1,190 @@
+package com.example.green.domain.challengecert.entity;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import com.example.green.domain.challenge.entity.TeamChallenge;
+import com.example.green.domain.challenge.entity.TeamChallengeGroup;
+import com.example.green.domain.challenge.enums.ChallengeStatus;
+import com.example.green.domain.challenge.enums.ChallengeType;
+import com.example.green.domain.challenge.enums.GroupStatus;
+import com.example.green.domain.challenge.utils.ChallengeCodeGenerator;
+import com.example.green.domain.challengecert.entity.enums.GroupRoleType;
+import com.example.green.domain.member.entity.Member;
+import com.example.green.domain.point.entity.vo.PointAmount;
+import com.example.green.global.error.exception.BusinessException;
+
+/**
+ * TeamChallengeParticipation 테스트
+ */
+class TeamChallengeParticipationTest {
+
+	private TeamChallengeParticipation participation;
+	private TeamChallengeGroup teamChallengeGroup;
+	private TeamChallenge teamChallenge;
+	private Member member;
+	private LocalDateTime now;
+
+	@BeforeEach
+	void setUp() {
+		now = LocalDateTime.now();
+
+		// 테스트용 Member 객체 생성
+		member = Member.create("google 123456789", "테스트유저", "test@example.com");
+
+		// 테스트용 TeamChallenge 생성
+		teamChallenge = TeamChallenge.create(
+			ChallengeCodeGenerator.generate(ChallengeType.TEAM, now),
+			"팀 챌린지",
+			ChallengeStatus.PROCEEDING,
+			PointAmount.of(BigDecimal.valueOf(2000)),
+			now.minusDays(1),
+			now.plusDays(7),
+			5,
+			"challenge-image.jpg",
+			"팀 챌린지 설명"
+		);
+
+		// 테스트용 TeamChallengeGroup 생성
+		teamChallengeGroup = TeamChallengeGroup.create(
+			"테스트 그룹",
+			GroupStatus.PROCEEDING,
+			now.minusHours(2),
+			now.plusDays(6),
+			10,
+			"서울시 강남구",
+			"테스트 그룹 설명",
+			"https://openchat.example.com"
+		);
+
+		// 팀 챌린지에 그룹 추가
+		teamChallenge.addChallengeGroup(teamChallengeGroup);
+
+		// 테스트용 TeamChallengeParticipation 생성 (멤버로 참여)
+		participation = TeamChallengeParticipation.createMember(
+			teamChallengeGroup,
+			member,
+			now.minusHours(1)
+		);
+	}
+
+	@Test
+	void createLeader_메서드로_팀_리더_참여를_생성할_수_있다() {
+		// given
+		Member leader = Member.create("google 111111111", "팀리더", "leader@example.com");
+		LocalDateTime participatedAt = now.minusMinutes(30);
+
+		// when
+		TeamChallengeParticipation leaderParticipation = TeamChallengeParticipation.createLeader(
+			teamChallengeGroup,
+			leader,
+			participatedAt
+		);
+
+		// then
+		assertThat(leaderParticipation.getTeamChallengeGroup()).isEqualTo(teamChallengeGroup);
+		assertThat(leaderParticipation.getMember()).isEqualTo(leader);
+		assertThat(leaderParticipation.getGroupRoleType()).isEqualTo(GroupRoleType.LEADER);
+		assertThat(leaderParticipation.getParticipatedAt()).isEqualTo(participatedAt);
+		assertThat(leaderParticipation.isLeader()).isTrue();
+	}
+
+	@Test
+	void createMember_메서드로_팀원_참여를_생성할_수_있다() {
+		// given
+		Member teamMember = Member.create("google 222222222", "팀원", "member@example.com");
+		LocalDateTime participatedAt = now.minusMinutes(15);
+
+		// when
+		TeamChallengeParticipation memberParticipation = TeamChallengeParticipation.createMember(
+			teamChallengeGroup,
+			teamMember,
+			participatedAt
+		);
+
+		// then
+		assertThat(memberParticipation.getTeamChallengeGroup()).isEqualTo(teamChallengeGroup);
+		assertThat(memberParticipation.getMember()).isEqualTo(teamMember);
+		assertThat(memberParticipation.getGroupRoleType()).isEqualTo(GroupRoleType.MEMBER);
+		assertThat(memberParticipation.getParticipatedAt()).isEqualTo(participatedAt);
+		assertThat(memberParticipation.isLeader()).isFalse();
+	}
+
+	@Test
+	void 팀_챌린지_그룹이_null이면_예외가_발생한다() {
+		// when & then
+		assertThatThrownBy(() -> TeamChallengeParticipation.createMember(
+			null,
+			member,
+			now
+		))
+			.isInstanceOf(BusinessException.class);
+
+		assertThatThrownBy(() -> TeamChallengeParticipation.createLeader(
+			null,
+			member,
+			now
+		))
+			.isInstanceOf(BusinessException.class);
+
+	}
+
+	@Test
+	void 회원이_null이면_예외가_발생한다() {
+		// when & then
+		assertThatThrownBy(() -> TeamChallengeParticipation.createMember(
+			teamChallengeGroup,
+			null,
+			now
+		))
+			.isInstanceOf(BusinessException.class);
+
+		assertThatThrownBy(() -> TeamChallengeParticipation.createLeader(
+			teamChallengeGroup,
+			null,
+			now
+		))
+			.isInstanceOf(BusinessException.class);
+
+	}
+
+	@Test
+	void 참여_시각이_null이면_예외가_발생한다() {
+		// when & then
+		assertThatThrownBy(() -> TeamChallengeParticipation.createMember(
+			teamChallengeGroup,
+			member,
+			null
+		))
+			.isInstanceOf(BusinessException.class);
+
+		assertThatThrownBy(() -> TeamChallengeParticipation.createLeader(
+			teamChallengeGroup,
+			member,
+			null
+		))
+			.isInstanceOf(BusinessException.class);
+
+	}
+
+	@Test
+	void 리더는_isLeader_메서드에서_true를_반환한다() {
+		// given
+		Member leader = Member.create("google 333333333", "팀리더", "leader@example.com");
+
+		TeamChallengeParticipation leaderParticipation = TeamChallengeParticipation.createLeader(
+			teamChallengeGroup,
+			leader,
+			now.minusMinutes(30)
+		);
+
+		// when & then
+		assertThat(leaderParticipation.isLeader()).isTrue();
+		assertThat(leaderParticipation.getGroupRoleType()).isEqualTo(GroupRoleType.LEADER);
+	}
+}


### PR DESCRIPTION
## #️⃣ 연관된 이슈
closed #104 

## 📝 작업 내용
- 챌린지 참여 엔티티 생성 (챌린지-멤버 중간 테이블)
- 챌린지 인증 엔티티 생성 (팀, 개인 챌린지 인증 엔티티)

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 명칭

### 📌 PR 진행 시 참고사항
- 리뷰어는 좋은 코드 방향을 제시하되, **수정을 강요하지 않습니다.**
- 좋은 코드를 발견하면 **칭찬과 격려를 아끼지 않습니다.**
- 리뷰는 Reviewer로 지정된 시점 기준으로 **3일 이내**에 진행해 주세요.
- Comment 작성 시 아래 Prefix를 사용해 주세요:
    - `P1`: 꼭 반영해 주세요 (Request Changes) – 이슈나 취약점 관련
    - `P2`: 반영을 고려해 주세요 (Comment) – 개선 의견
    - `P3`: 단순 제안 (Chore)
