### PR TITLE
[HOTFIX/#129] SecurityFilterChain 분리 및 JwtFilter 로직 

### DIFF
--- a/src/main/java/com/example/green/domain/auth/filter/JwtFilter.java
+++ b/src/main/java/com/example/green/domain/auth/filter/JwtFilter.java
@@ -17,6 +17,12 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.extern.slf4j.Slf4j;
 
+/**
+ * JWT 토큰 검증 필터
+ * OAuth2 경로나 정적 리소스에는 적용되지 않으므로 경로 제외 로직이 불필요합니다.
+ * - 유효한 토큰: SecurityContext에 인증 정보 저장
+ * - 무효한/없는 토큰: SecurityContext 비워둠 → @PreAuthorize에서 최종 권한 검증
+ */
 @Slf4j
 public class JwtFilter extends OncePerRequestFilter {
 
@@ -37,7 +43,7 @@ public class JwtFilter extends OncePerRequestFilter {
 		String accessTokenString = extractAccessTokenFromHeader(request);
 
 		if (accessTokenString == null) {
-			log.debug("AccessToken not found in Authorization header");
+			log.debug("AccessToken not found in Authorization header for path: {}", request.getRequestURI());
 			filterChain.doFilter(request, response);
 			return;
 		}
@@ -52,10 +58,8 @@ public class JwtFilter extends OncePerRequestFilter {
 				return;
 			}
 
-			// TokenService에서 memberId포함해서 Authentication 생성
 			Authentication authToken = tokenService.createAuthentication(accessTokenString);
 
-			// SecurityContext에 인증 정보 저장
 			SecurityContextHolder.getContext().setAuthentication(authToken);
 
 			log.debug("JWT authentication completed for user: {}", accessToken.getMemberKey());
@@ -83,6 +87,5 @@ public class JwtFilter extends OncePerRequestFilter {
 		}
 		return null;
 	}
-
 }
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -46,7 +46,7 @@ spring:
             client-name: ${OAUTH2_GOOGLE_CLIENT_NAME:google}
             client-id: ${OAUTH2_GOOGLE_CLIENT_ID}
             client-secret: ${OAUTH2_GOOGLE_CLIENT_SECRET}
-            redirect-uri: ${OAUTH2_GOOGLE_REDIRECT_URI:https://www.greenwinit.store/login/oauth2/code/google}
+            redirect-uri: ${OAUTH2_GOOGLE_REDIRECT_URI:https://api.greenwinit.store/login/oauth2/code/google}
             authorization-grant-type: ${OAUTH2_GOOGLE_GRANT_TYPE:authorization_code}
             scope: ${OAUTH2_GOOGLE_SCOPE:profile,email}
 
@@ -75,7 +75,7 @@ app:
   frontend:
     base-url: ${FRONTEND_URL:https://www.greenwinit.store}
   backend:
-    base-url: ${BACKEND_URL:https://www.greenwinit.store}
+    base-url: ${BACKEND_URL:https://api.greenwinit.store}
 
 jwt:
   secret: ${JWT_SECRET}


### PR DESCRIPTION


## #️⃣ 연관된 이슈
https://github.com/GreenWiNit/backend/issues/129

> ex) close #Issue number

## 📝 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

- OAuth2 엔드포인트에서 302 리다이렉트 대신 200 반환 문제 해결
-` @PublicApi `어노테이션 사용 시 유효하지 않은 토큰으로 인한 UX 저해 문제 해결
- JwtFilter의 shouldNotFilter() 로직 제거로 코드 간소화
- OAuth2 redirect-uri를 api.greenwinit.store로 수정


### 🚨 문제 상황
`@PublicAp`i 어노테이션 관련 JwtFilter 수정 후 OAuth2 로그인 플로우에서 예상치 못한 동작 발생
1. OAuth2 엔드포인트 302 → 200 문제: OAuth2 로그인 시 정상적인 302 리다이렉트 대신 200 응답 반환으로 로그인 플로우 중단
2. `@PublicApi` UX 저해: 공개 API에서도 잘못된 토큰 전송 시 불필요한 인증 오류 발생으로 사용자 경험 악화

🔧 해결 방안: Multiple SecurityFilterChain 도입
기존 단일 FilterChain을 경로별로 분리하여 각각 최적화된 보안 정책 적용

```
// FilterChain 1: OAuth2 및 정적 리소스 (JWT 필터 없음)
@Order(1) oauthAndStaticResourcesSecurityFilterChain()

// FilterChain 2: API 엔드포인트 (JWT 필터 적용)  
@Order(2) apiSecurityFilterChain()
```

2️⃣ 핵심 개선사항
1. OAuth2 플로우 보호
- /oauth2/**, /login/** 경로에서 JWT 필터 완전 제외
- OAuth2 인증 플로우의 302 리다이렉트 보장
- 세션 기반 인증으로 적절한 상태 관리
2. API 엔드포인트 최적화
- /api/** 경로에만 JWT 필터 적용
- `@PublicApi`: JWT 필터 거치지만 permitAll()로 접근 허용 (UX 개선)
- `@AuthenticatedApi`: JWT 필터 + isAuthenticated() 검증으로 보안 강화
- 
3️⃣ 설정 수정
OAuth2 redirect-uri: www.greenwinit.store → api.greenwinit.store 

## 📷 스크린샷

> 이미지

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 명칭

### 📌 PR 진행 시 참고사항
- 리뷰어는 좋은 코드 방향을 제시하되, **수정을 강요하지 않습니다.**
- 좋은 코드를 발견하면 **칭찬과 격려를 아끼지 않습니다.**
- 리뷰는 Reviewer로 지정된 시점 기준으로 **3일 이내**에 진행해 주세요.
- Comment 작성 시 아래 Prefix를 사용해 주세요:
    - `P1`: 꼭 반영해 주세요 (Request Changes) – 이슈나 취약점 관련
    - `P2`: 반영을 고려해 주세요 (Comment) – 개선 의견
    - `P3`: 단순 제안 (Chore)
