### PR TITLE
fix: restore withdrawn member status when creating refresh token

### DIFF
--- a/src/main/java/com/example/green/domain/auth/service/TokenService.java
+++ b/src/main/java/com/example/green/domain/auth/service/TokenService.java
@@ -151,11 +151,14 @@ public class TokenService {
 				.signWith(secretKey)
 				.compact();
 
-			Member member = memberService.findActiveByMemberKey(memberKey)
+			Member member = memberService.findByMemberKey(memberKey)
 				.orElseThrow(() -> {
-					log.error("TokenManager 생성 실패: 활성 사용자를 찾을 수 없음 (탈퇴했거나 존재하지 않음) - {}", memberKey);
+					log.error("TokenManager 생성 실패: 사용자를 찾을 수 없음 - {}", memberKey);
 					return new BusinessException(MemberExceptionMessage.MEMBER_NOT_FOUND);
 				});
+			if (member.isWithdrawn()) {
+				memberService.restoreStatusToNormal(member);
+			}
 
 			// 기존 토큰 정리 (선택적: 한 사용자당 최대 토큰 수 제한)
 			cleanupOldTokens(memberKey);

--- a/src/main/java/com/example/green/domain/auth/service/TokenService.java
+++ b/src/main/java/com/example/green/domain/auth/service/TokenService.java
@@ -156,6 +156,7 @@ public class TokenService {
 					log.error("TokenManager 생성 실패: 사용자를 찾을 수 없음 - {}", memberKey);
 					return new BusinessException(MemberExceptionMessage.MEMBER_NOT_FOUND);
 				});
+			
 			if (member.isWithdrawn()) {
 				memberService.restoreStatusToNormal(member);
 			}

--- a/src/main/java/com/example/green/domain/member/entity/Member.java
+++ b/src/main/java/com/example/green/domain/member/entity/Member.java
@@ -104,6 +104,11 @@ public class Member extends BaseEntity {
 		this.markDeleted();
 	}
 
+	public void restoreStatusToNormal() {
+		this.status = MemberStatus.NORMAL;
+		this.restore();
+	}
+
 	public boolean isWithdrawn() {
 		return this.status == MemberStatus.DELETED || this.isDeleted();
 	}

--- a/src/main/java/com/example/green/domain/member/repository/MemberRepository.java
+++ b/src/main/java/com/example/green/domain/member/repository/MemberRepository.java
@@ -13,6 +13,10 @@ import com.example.green.domain.member.entity.Member;
 import com.example.green.domain.member.entity.enums.MemberStatus;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
+	/**
+	 * 회원 키로 회원 조회
+	 */
+	@Query("SELECT m FROM Member m WHERE m.memberKey = :memberKey")
 	Optional<Member> findByMemberKey(String memberKey);
 
 	boolean existsByMemberKey(String memberKey);

--- a/src/main/java/com/example/green/domain/member/service/MemberService.java
+++ b/src/main/java/com/example/green/domain/member/service/MemberService.java
@@ -180,7 +180,7 @@ public class MemberService {
 	 * 탈퇴한 회원에서 다시 가입한 회원으로 전환
 	 * 작성일 기준 createRefreshToken에서 사용
 	 */
-	@Transactional(readOnly = true)
+	@Transactional
 	public void restoreStatusToNormal(Member member) {
 		member.restoreStatusToNormal();
 	}

--- a/src/main/java/com/example/green/domain/member/service/MemberService.java
+++ b/src/main/java/com/example/green/domain/member/service/MemberService.java
@@ -169,6 +169,23 @@ public class MemberService {
 	}
 
 	/**
+	 * 회원 키로 회원 조회
+	 */
+	@Transactional(readOnly = true)
+	public Optional<Member> findByMemberKey(String memberKey) {
+		return memberRepository.findByMemberKey(memberKey);
+	}
+
+	/**
+	 * 탈퇴한 회원에서 다시 가입한 회원으로 전환
+	 * 작성일 기준 createRefreshToken에서 사용
+	 */
+	@Transactional(readOnly = true)
+	public void restoreStatusToNormal(Member member) {
+		member.restoreStatusToNormal();
+	}
+
+	/**
 	 * 활성 회원 존재 여부 확인
 	 */
 	@Transactional(readOnly = true)

--- a/src/test/java/com/example/green/domain/auth/service/TokenServiceWithdrawnMemberTest.java
+++ b/src/test/java/com/example/green/domain/auth/service/TokenServiceWithdrawnMemberTest.java
@@ -1,0 +1,83 @@
+package com.example.green.domain.auth.service;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.BDDMockito.*;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.example.green.domain.member.entity.Member;
+import com.example.green.domain.member.entity.enums.MemberStatus;
+import com.example.green.domain.member.service.MemberService;
+
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("JWT 토큰 생성 실패 문제 해결 테스트")
+class TokenServiceWithdrawnMemberTest {
+
+	@Mock
+	private MemberService memberService;
+
+	@Test
+	@DisplayName("BEFORE: 원래 방식으로는 탈퇴한 사용자를 찾을 수 없었음")
+	void shouldNotFindWithdrawnUserWithOriginalApproach() {
+		// Given
+		String memberKey = "google 123456789";
+
+		given(memberService.findActiveByMemberKey(memberKey))
+			.willReturn(Optional.empty());
+
+		// When
+		Optional<Member> activeMember = memberService.findActiveByMemberKey(memberKey);
+
+		// Then
+		assertThat(activeMember).isEmpty();
+	}
+
+	@Test
+	@DisplayName("AFTER: 해결된 방식으로는 탈퇴한 사용자를 찾아서 복원 가능")
+	void shouldFindAndRestoreWithdrawnUserWithFixedApproach() {
+		// Given
+		String memberKey = "google 123456789";
+		Member withdrawnMember = Member.create(memberKey, "홍길동", "test@example.com");
+		withdrawnMember.withdraw();
+
+		given(memberService.findByMemberKey(memberKey))
+			.willReturn(Optional.of(withdrawnMember));
+
+		// When
+		Optional<Member> foundMember = memberService.findByMemberKey(memberKey);
+
+		// Then
+		assertThat(foundMember).isPresent();
+		assertThat(foundMember.get().isWithdrawn()).isTrue();
+
+		Member member = foundMember.get();
+		memberService.restoreStatusToNormal(member);
+
+		verify(memberService).restoreStatusToNormal(member);
+	}
+
+	@Test
+	@DisplayName("복원된 사용자는 정상 상태가 되어야 함")
+	void shouldRestoreMemberToNormalStatus() {
+		// Given
+		Member withdrawnMember = Member.create("google 123456789", "홍길동", "test@example.com");
+		withdrawnMember.withdraw();
+
+		assertThat(withdrawnMember.getStatus()).isEqualTo(MemberStatus.DELETED);
+		assertThat(withdrawnMember.isWithdrawn()).isTrue();
+
+		// When
+		withdrawnMember.restoreStatusToNormal();
+
+		// Then
+		assertThat(withdrawnMember.getStatus()).isEqualTo(MemberStatus.NORMAL);
+		assertThat(withdrawnMember.isWithdrawn()).isFalse();
+	}
+} 

--- a/src/test/java/com/example/green/domain/member/service/MemberServiceWithdrawnRestoreTest.java
+++ b/src/test/java/com/example/green/domain/member/service/MemberServiceWithdrawnRestoreTest.java
@@ -1,0 +1,175 @@
+package com.example.green.domain.member.service;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.*;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.springframework.dao.DataIntegrityViolationException;
+
+import com.example.green.domain.common.service.FileManager;
+import com.example.green.domain.member.entity.Member;
+import com.example.green.domain.member.entity.enums.MemberStatus;
+import com.example.green.domain.member.repository.MemberRepository;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+@DisplayName("MemberService 탈퇴 사용자 복원 테스트")
+class MemberServiceWithdrawnRestoreTest {
+
+	@Mock
+	private MemberRepository memberRepository;
+
+	@Mock
+	private FileManager fileManager;
+
+	@InjectMocks
+	private MemberService memberService;
+
+	@Test
+	@DisplayName("탈퇴한 사용자가 재가입 시 새 정보로 복원되어야 한다")
+	void shouldRestoreWithdrawnMemberWithNewInfo() {
+		// Given
+		String memberKey = "google 123456789";
+		String name = "홍길동";
+		String email = "test@example.com";
+		String newNickname = "새로운닉네임";
+		String newProfileImageUrl = "https://example.com/new-profile.jpg";
+
+		Member withdrawnMember = Member.create(memberKey, "기존이름", "old@example.com");
+		withdrawnMember.withdraw();
+
+		given(memberRepository.findByMemberKey(memberKey))
+			.willReturn(Optional.of(withdrawnMember));
+
+		// When
+		String result = memberService.signupFromOAuth2(
+			"google", "123456789", name, email, newNickname, newProfileImageUrl
+		);
+
+		// Then
+		assertThat(result).isEqualTo(memberKey);
+		assertThat(withdrawnMember.getStatus()).isEqualTo(MemberStatus.NORMAL);
+		assertThat(withdrawnMember.isWithdrawn()).isFalse();
+		assertThat(withdrawnMember.getName()).isEqualTo(name);
+		assertThat(withdrawnMember.getEmail()).isEqualTo(email);
+		assertThat(withdrawnMember.getProfile().getNickname()).isEqualTo(newNickname);
+		assertThat(withdrawnMember.getProfile().getProfileImageUrl()).isEqualTo(newProfileImageUrl);
+	}
+
+	@Test
+	@DisplayName("존재하지 않는 사용자는 새로 생성해야 한다")
+	void shouldCreateNewMemberWhenNotExists() {
+		// Given
+		String memberKey = "google 123456789";
+		String name = "홍길동";
+		String email = "test@example.com";
+		String nickname = "닉네임";
+		String profileImageUrl = "https://example.com/profile.jpg";
+
+		given(memberRepository.findByMemberKey(memberKey))
+			.willReturn(Optional.empty());
+
+		// When
+		String result = memberService.signupFromOAuth2(
+			"google", "123456789", name, email, nickname, profileImageUrl
+		);
+
+		// Then
+		assertThat(result).isEqualTo(memberKey);
+		verify(memberRepository).save(any(Member.class));
+	}
+
+	@Test
+	@DisplayName("동시 회원가입 시 중복 예외 처리가 정상 작동해야 한다")
+	void shouldHandleConcurrentSignupGracefully() {
+		// Given
+		String memberKey = "google 123456789";
+		String name = "홍길동";
+		String email = "test@example.com";
+
+		given(memberRepository.findByMemberKey(memberKey))
+			.willReturn(Optional.empty());
+		given(memberRepository.save(any(Member.class)))
+			.willThrow(new DataIntegrityViolationException("Duplicate key"));
+
+		// When
+		String result = memberService.signupFromOAuth2(
+			"google", "123456789", name, email, "닉네임", "profile.jpg"
+		);
+
+		// Then
+		assertThat(result).isEqualTo(memberKey);
+	}
+
+	@Test
+	@DisplayName("탈퇴 사용자 복원 시 멱등성이 보장되어야 한다")
+	void shouldEnsureIdempotencyOnRestore() {
+		// Given
+		String memberKey = "google 123456789";
+		Member withdrawnMember = Member.create(memberKey, "홍길동", "test@example.com");
+		withdrawnMember.withdraw();
+
+		// When
+		memberService.restoreStatusToNormal(withdrawnMember);
+		memberService.restoreStatusToNormal(withdrawnMember);
+
+		// Then
+		assertThat(withdrawnMember.getStatus()).isEqualTo(MemberStatus.NORMAL);
+		assertThat(withdrawnMember.isWithdrawn()).isFalse();
+	}
+
+	@Test
+	@DisplayName("활성 사용자 존재 여부 확인이 정확해야 한다")
+	void shouldCheckActiveUserExistenceCorrectly() {
+		// Given
+		String activeUserKey = "google 111111111";
+		String withdrawnUserKey = "google 222222222";
+
+		given(memberRepository.existsActiveByMemberKey(activeUserKey))
+			.willReturn(true);
+		given(memberRepository.existsActiveByMemberKey(withdrawnUserKey))
+			.willReturn(false);
+
+		// When & Then
+		assertThat(memberService.existsActiveByMemberKey(activeUserKey)).isTrue();
+		assertThat(memberService.existsActiveByMemberKey(withdrawnUserKey)).isFalse();
+	}
+
+	@Test
+	@DisplayName("탈퇴한 사용자 재가입 시 OAuth2 정보와 사용자 입력이 모두 반영되어야 한다")
+	void shouldUpdateBothOAuth2InfoAndUserInput() {
+		// Given
+		String memberKey = "google 123456789";
+		Member withdrawnMember = Member.create(memberKey, "기존이름", "old@example.com");
+		withdrawnMember.updateProfile("기존닉네임", "old-profile.jpg");
+		withdrawnMember.withdraw();
+
+		given(memberRepository.findByMemberKey(memberKey))
+			.willReturn(Optional.of(withdrawnMember));
+
+		// When
+		memberService.signupFromOAuth2(
+			"google", "123456789", 
+			"홍길동 Updated",
+			"new@example.com",
+			"새로운닉네임",
+			"new-profile.jpg"
+		);
+
+		// Then
+		assertThat(withdrawnMember.getName()).isEqualTo("홍길동 Updated");
+		assertThat(withdrawnMember.getEmail()).isEqualTo("new@example.com");
+		assertThat(withdrawnMember.getProfile().getNickname()).isEqualTo("새로운닉네임");
+		assertThat(withdrawnMember.getProfile().getProfileImageUrl()).isEqualTo("new-profile.jpg");
+	}
+} 

--- a/src/test/java/com/example/integration/auth/WithdrawnMemberReSignupIntegrationTest.java
+++ b/src/test/java/com/example/integration/auth/WithdrawnMemberReSignupIntegrationTest.java
@@ -1,0 +1,212 @@
+package com.example.integration.auth;
+
+import static org.assertj.core.api.Assertions.*;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.example.green.domain.auth.dto.TempTokenInfoDto;
+import com.example.green.domain.auth.service.AuthService;
+import com.example.green.domain.auth.service.CustomOAuth2UserService;
+import com.example.green.domain.auth.service.TokenService;
+import com.example.green.domain.member.entity.Member;
+import com.example.green.domain.member.entity.enums.MemberStatus;
+import com.example.green.domain.member.repository.MemberRepository;
+import com.example.green.domain.member.service.MemberService;
+import com.example.integration.common.BaseIntegrationTest;
+
+@DisplayName("탈퇴한 사용자 재가입 플로우 테스트")
+class WithdrawnMemberReSignupIntegrationTest extends BaseIntegrationTest {
+
+	@Autowired
+	private MemberService memberService;
+
+	@Autowired
+	private AuthService authService;
+
+	@Autowired
+	private TokenService tokenService;
+
+	@Autowired
+	private CustomOAuth2UserService customOAuth2UserService;
+
+	@Autowired
+	private MemberRepository memberRepository;
+
+	private Member withdrawnMember;
+	private String memberKey;
+	private String originalNickname;
+	private String newNickname;
+	private String newProfileImageUrl;
+
+	@BeforeEach
+	void setUp() {
+		// Given: 기존 회원 생성 및 탈퇴 처리
+		memberKey = "google 123456789";
+		originalNickname = "원래닉네임";
+		newNickname = "새로운닉네임";
+		newProfileImageUrl = "https://example.com/new-profile.jpg";
+
+		// 1. 기존 회원 생성
+		String originalMemberKey = memberService.signupFromOAuth2(
+			"google", 
+			"123456789", 
+			"홍길동", 
+			"test@example.com",
+			originalNickname,
+			"https://example.com/old-profile.jpg"
+		);
+
+		withdrawnMember = memberRepository.findByMemberKey(originalMemberKey).orElseThrow();
+
+		// 2. 회원 탈퇴 처리
+		withdrawnMember.withdraw();
+		memberRepository.save(withdrawnMember);
+
+		// 탈퇴 상태 확인
+		assertThat(withdrawnMember.isWithdrawn()).isTrue();
+		assertThat(withdrawnMember.getStatus()).isEqualTo(MemberStatus.DELETED);
+	}
+
+	@Test
+	@DisplayName("탈퇴한 사용자는 신규 사용자로 인식되어야 한다")
+	void shouldRecognizeWithdrawnUserAsNewUser() {
+		// When: 활성 사용자 존재 여부 확인
+		boolean isExistingUser = memberService.existsActiveByMemberKey(memberKey);
+
+		// Then: 탈퇴한 사용자는 활성 사용자가 아니므로 false
+		assertThat(isExistingUser).isFalse();
+	}
+
+	@Test
+	@DisplayName("탈퇴한 사용자 재가입 시 새 정보로 복원되어야 한다")
+	@Transactional
+	void shouldRestoreWithdrawnMemberWithNewInfo() {
+		// When: 재가입 처리
+		TempTokenInfoDto tempInfo = TempTokenInfoDto.builder()
+			.provider("google")
+			.providerId("123456789")
+			.name("홍길동")
+			.email("test@example.com")
+			.build();
+
+		String resultMemberKey = authService.signup(tempInfo, newNickname, newProfileImageUrl);
+
+		// Then: 동일한 memberKey 반환
+		assertThat(resultMemberKey).isEqualTo(memberKey);
+
+		// 회원 상태 및 정보 확인
+		Member restoredMember = memberRepository.findByMemberKey(memberKey).orElseThrow();
+		
+		assertThat(restoredMember.getStatus()).isEqualTo(MemberStatus.NORMAL);
+		assertThat(restoredMember.isWithdrawn()).isFalse();
+		assertThat(restoredMember.getProfile().getNickname()).isEqualTo(newNickname);
+		assertThat(restoredMember.getProfile().getProfileImageUrl()).isEqualTo(newProfileImageUrl);
+	}
+
+	@Test
+	@DisplayName("복원된 사용자로 토큰 생성이 성공해야 한다")
+	@Transactional
+	void shouldCreateTokenAfterRestore() {
+		// Given: 재가입 처리
+		TempTokenInfoDto tempInfo = TempTokenInfoDto.builder()
+			.provider("google")
+			.providerId("123456789")
+			.name("홍길동")
+			.email("test@example.com")
+			.build();
+
+		authService.signup(tempInfo, newNickname, newProfileImageUrl);
+
+		// When: 토큰 생성 시도
+		String refreshToken = tokenService.createRefreshToken(memberKey, "Web Browser", "127.0.0.1");
+		String accessToken = tokenService.createAccessToken(memberKey, "ROLE_USER");
+
+		// Then: 토큰 생성 성공
+		assertThat(refreshToken).isNotBlank();
+		assertThat(accessToken).isNotBlank();
+
+		// 토큰 검증
+		boolean isValidRefresh = tokenService.validateRefreshToken(refreshToken);
+		boolean isValidAccess = tokenService.validateAccessToken(accessToken);
+
+		assertThat(isValidRefresh).isTrue();
+		assertThat(isValidAccess).isTrue();
+	}
+
+	@Test
+	@DisplayName("전체 플로우: 탈퇴 -> OAuth2 인식 -> 재가입 -> 토큰 생성")
+	@Transactional
+	void shouldCompleteFullReSignupFlow() {
+		// 1. OAuth2 신규 사용자 인식 확인
+		boolean isExistingUser = memberService.existsActiveByMemberKey(memberKey);
+		assertThat(isExistingUser).isFalse();
+
+		// 2. 재가입 처리
+		TempTokenInfoDto tempInfo = TempTokenInfoDto.builder()
+			.provider("google")
+			.providerId("123456789")
+			.name("홍길동 Updated")  // OAuth2에서 받은 최신 정보
+			.email("test@example.com")
+			.build();
+
+		String resultMemberKey = authService.signup(tempInfo, newNickname, newProfileImageUrl);
+
+		// 3. 복원 확인
+		Member restoredMember = memberRepository.findByMemberKey(memberKey).orElseThrow();
+		assertThat(restoredMember.getStatus()).isEqualTo(MemberStatus.NORMAL);
+		assertThat(restoredMember.getName()).isEqualTo("홍길동 Updated");
+		assertThat(restoredMember.getProfile().getNickname()).isEqualTo(newNickname);
+
+		// 4. 토큰 생성 성공
+		String refreshToken = tokenService.createRefreshToken(memberKey, "Web Browser", "127.0.0.1");
+		assertThat(refreshToken).isNotBlank();
+
+		// 5. 최종 상태 확인: 완전히 활성 상태
+		boolean isFinallyActive = memberService.existsActiveByMemberKey(memberKey);
+		assertThat(isFinallyActive).isTrue();
+	}
+
+	@Test
+	@DisplayName("TokenService에서도 백업 복원이 정상 작동해야 한다")
+	@Transactional
+	void shouldBackupRestoreWorkInTokenService() {
+
+		String refreshToken = tokenService.createRefreshToken(memberKey, "Web Browser", "127.0.0.1");
+
+		assertThat(refreshToken).isNotBlank();
+
+		Member restoredMember = memberRepository.findByMemberKey(memberKey).orElseThrow();
+		assertThat(restoredMember.getStatus()).isEqualTo(MemberStatus.NORMAL);
+		assertThat(restoredMember.isWithdrawn()).isFalse();
+	}
+
+	@Test
+	@DisplayName("이중 복원 호출시 멱등성이 보장되어야 한다")
+	@Transactional
+	void shouldEnsureIdempotencyOnDoubleRestore() {
+		// Given
+		TempTokenInfoDto tempInfo = TempTokenInfoDto.builder()
+			.provider("google")
+			.providerId("123456789")
+			.name("홍길동")
+			.email("test@example.com")
+			.build();
+
+		authService.signup(tempInfo, newNickname, newProfileImageUrl);
+		
+		Member firstRestore = memberRepository.findByMemberKey(memberKey).orElseThrow();
+		String firstNickname = firstRestore.getProfile().getNickname();
+
+		// When
+		tokenService.createRefreshToken(memberKey, "Web Browser", "127.0.0.1");
+
+		// Then
+		Member secondRestore = memberRepository.findByMemberKey(memberKey).orElseThrow();
+		assertThat(secondRestore.getProfile().getNickname()).isEqualTo(firstNickname);
+		assertThat(secondRestore.getStatus()).isEqualTo(MemberStatus.NORMAL);
+	}
+} 


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #184

## 📝 작업 내용

## 📷 스크린샷

## 💬 리뷰 요구사항(선택)

### 📌 PR 진행 시 참고사항
- 리뷰어는 좋은 코드 방향을 제시하되, **수정을 강요하지 않습니다.**
- 좋은 코드를 발견하면 **칭찬과 격려를 아끼지 않습니다.**
- 리뷰는 Reviewer로 지정된 시점 기준으로 **3일 이내**에 진행해 주세요.
- Comment 작성 시 아래 Prefix를 사용해 주세요:
    - `P1`: 꼭 반영해 주세요 (Request Changes) – 이슈나 취약점 관련
    - `P2`: 반영을 고려해 주세요 (Comment) – 개선 의견
    - `P3`: 단순 제안 (Chore)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved member management by allowing withdrawn members to have their status automatically restored to normal when refreshing tokens.
  * Added support for restoring withdrawn members during re-signup with updated profile and OAuth2 information.
  * Introduced new methods to retrieve members regardless of active status and to restore withdrawn members.
  * Enhanced token creation flow to handle restored members seamlessly.

* **Documentation**
  * Enhanced code documentation for member lookup functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->