### PR TITLE
fix : [정보공유] 정보 수정 로직 순서 변경 (#213)

### DIFF
--- a/src/test/java/com/example/integration/info/InfoServiceIntTest.java
+++ b/src/test/java/com/example/integration/info/InfoServiceIntTest.java
@@ -1,6 +1,7 @@
 package com.example.integration.info;
 
 import static org.assertj.core.api.Assertions.*;
+import static org.mockito.Mockito.*;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -172,6 +173,28 @@ class InfoServiceIntTest extends BaseIntegrationTest {
 				assertThat(response.infoCategoryCode()).isEqualTo("ETC"); // 컨텐츠 -> 기타
 				assertThat(response.infoCategoryName()).isEqualTo("기타");
 				assertThat(response.imageurl()).isEqualTo(updateRequest.imageUrl());
+			}
+
+			@Test
+			void 정보_수정시_이미지URL이_같으면_기존_이미지_URL을_유지한다() {
+				// given
+				InfoRequest updateRequest = InfoRequest.builder()
+					.title("updateTitle")
+					.content("updateContent")
+					.infoCategory(InfoCategory.ETC)
+					.imageUrl(infoEntity.getImageUrl()) // 기존 이미지 URL과 동일
+					.isDisplay("N")
+					.build();
+
+				// when
+				var response = infoService.updateInfo(infoEntity.getId(), updateRequest);
+
+				// then - 결과 값 검증
+				assertThat(response.imageurl()).isEqualTo(infoEntity.getImageUrl());
+
+				// then - 메서드 호출 여부 검증
+				verify(fileManager, never()).unUseImage(anyString());
+				verify(fileManager, never()).confirmUsingImage(anyString());
 			}
 
 			@Test


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> ex) close #Issue number

## 📝 작업 내용

- 기존 이미지와 신규 이미지가 같을 때 기존 이미지 (= 신규 이미지) 를 unUse 처리후 다시 Confirm 처리 하는 과정에서 
- 삭제 flag를 읽어오며 발생한 Exception 처리를 개선하였습니다. 

## 📷 스크린샷

<img width="1658" height="710" alt="image" src="https://github.com/user-attachments/assets/791a4eb7-bd10-48fc-9f57-c4fe626bf555" />

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 명칭

### 📌 PR 진행 시 참고사항
- 리뷰어는 좋은 코드 방향을 제시하되, **수정을 강요하지 않습니다.**
- 좋은 코드를 발견하면 **칭찬과 격려를 아끼지 않습니다.**
- 리뷰는 Reviewer로 지정된 시점 기준으로 **3일 이내**에 진행해 주세요.
- Comment 작성 시 아래 Prefix를 사용해 주세요:
    - `P1`: 꼭 반영해 주세요 (Request Changes) – 이슈나 취약점 관련
    - `P2`: 반영을 고려해 주세요 (Comment) – 개선 의견
    - `P3`: 단순 제안 (Chore)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved image update handling to ensure that when the image URL remains unchanged during info updates, the original image is retained without unnecessary changes.

* **Tests**
  * Added a test to verify that updating info with the same image URL does not alter the image or trigger image usage updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->