### PR TITLE
fix : [정보공유] PageNated 형식에 맞는 Dto로 통일 (#232)

### DIFF
--- a/src/main/java/com/example/green/domain/info/controller/InfoController.java
+++ b/src/main/java/com/example/green/domain/info/controller/InfoController.java
@@ -17,13 +17,13 @@ import com.example.green.domain.info.domain.vo.InfoCategory;
 import com.example.green.domain.info.dto.InfoCategoryDto;
 import com.example.green.domain.info.dto.InfoRequest;
 import com.example.green.domain.info.dto.admin.InfoDetailResponseByAdmin;
-import com.example.green.domain.info.dto.admin.InfoSearchListResponseByAdmin;
 import com.example.green.domain.info.dto.admin.InfoSearchResponseByAdmin;
 import com.example.green.domain.info.dto.user.InfoDetailResponseByUser;
 import com.example.green.domain.info.dto.user.InfoSearchListResponseByUser;
 import com.example.green.domain.info.service.InfoService;
 import com.example.green.global.api.ApiTemplate;
 import com.example.green.global.api.NoContent;
+import com.example.green.global.api.page.PageTemplate;
 import com.example.green.global.excel.core.ExcelDownloader;
 import com.example.green.global.security.annotation.AdminApi;
 import com.example.green.global.security.annotation.AuthenticatedApi;
@@ -41,10 +41,11 @@ public class InfoController implements InfoControllerDocs {
 
 	@AdminApi(reason = "관리자만 정보 공유 목록 조회 가능")
 	@GetMapping("/api/admin/info")
-	public ApiTemplate<InfoSearchListResponseByAdmin> getInfosForAdmin(
+	public ApiTemplate<PageTemplate<InfoSearchResponseByAdmin>> getInfosForAdmin(
 		@RequestParam(name = "page", required = false) Integer page,
-		@RequestParam(name = "size", required = false) Integer size) {
-		InfoSearchListResponseByAdmin response = infoService.getInfosForAdmin(page, size);
+		@RequestParam(name = "size", required = false, defaultValue = "10") Integer size) {
+
+		PageTemplate<InfoSearchResponseByAdmin> response = infoService.getInfosForAdmin(page, size);
 		return ApiTemplate.ok(InfoResponseMessage.INFO_LIST_FOUND, response);
 	}
 

--- a/src/main/java/com/example/green/domain/info/controller/InfoControllerDocs.java
+++ b/src/main/java/com/example/green/domain/info/controller/InfoControllerDocs.java
@@ -5,11 +5,12 @@ import java.util.List;
 import com.example.green.domain.info.dto.InfoCategoryDto;
 import com.example.green.domain.info.dto.InfoRequest;
 import com.example.green.domain.info.dto.admin.InfoDetailResponseByAdmin;
-import com.example.green.domain.info.dto.admin.InfoSearchListResponseByAdmin;
+import com.example.green.domain.info.dto.admin.InfoSearchResponseByAdmin;
 import com.example.green.domain.info.dto.user.InfoDetailResponseByUser;
 import com.example.green.domain.info.dto.user.InfoSearchListResponseByUser;
 import com.example.green.global.api.ApiTemplate;
 import com.example.green.global.api.NoContent;
+import com.example.green.global.api.page.PageTemplate;
 import com.example.green.global.docs.ApiErrorStandard;
 import com.example.green.global.error.dto.DetailedExceptionResponse;
 import com.example.green.global.error.dto.ExceptionResponse;
@@ -30,9 +31,9 @@ public interface InfoControllerDocs {
 	@Operation(summary = "관리자 전체 Info 페이지 단위로 조회", description = "관리자가 페이징 정보를 기준으로 정보공유 목록을 조회합니다.")
 	@ApiErrorStandard
 	@ApiResponse(responseCode = "200", description = "관리자 정보공유 목록 조회 성공", useReturnTypeSchema = true)
-	ApiTemplate<InfoSearchListResponseByAdmin> getInfosForAdmin(
-		@Parameter(name = "page", description = "조회할 페이지 번호 (0부터 시작)", example = "0", required = true) Integer page,
-		@Parameter(name = "size", description = "페이지당 게시글 수 (20개로)", example = "20", required = true) Integer size
+	ApiTemplate<PageTemplate<InfoSearchResponseByAdmin>> getInfosForAdmin(
+		@Parameter(name = "page", description = "조회할 페이지 번호 (1부터 시작)", example = "1", required = false) Integer page,
+		@Parameter(name = "size", description = "페이지당 게시글 수 (기본값: 10, 최대: 100)", example = "10", required = false) Integer size
 	);
 
 	@Operation(

--- a/src/main/java/com/example/green/domain/info/repository/InfoRepository.java
+++ b/src/main/java/com/example/green/domain/info/repository/InfoRepository.java
@@ -3,10 +3,19 @@ package com.example.green.domain.info.repository;
 import java.util.List;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import com.example.green.domain.info.domain.InfoEntity;
 
 public interface InfoRepository extends JpaRepository<InfoEntity, String> {
+	@Query("""
+		SELECT i FROM InfoEntity i 
+		ORDER BY i.createdDate DESC
+		""")
+	List<InfoEntity> findAllWithPagination(@Param("offset") long offset, @Param("limit") int limit);
+
 	List<InfoEntity> findAllByOrderByCreatedDateDesc();
+
 }
 

--- a/src/main/java/com/example/green/domain/info/service/InfoService.java
+++ b/src/main/java/com/example/green/domain/info/service/InfoService.java
@@ -4,16 +4,16 @@ import java.util.List;
 
 import com.example.green.domain.info.dto.InfoRequest;
 import com.example.green.domain.info.dto.admin.InfoDetailResponseByAdmin;
-import com.example.green.domain.info.dto.admin.InfoSearchListResponseByAdmin;
 import com.example.green.domain.info.dto.admin.InfoSearchResponseByAdmin;
 import com.example.green.domain.info.dto.user.InfoDetailResponseByUser;
 import com.example.green.domain.info.dto.user.InfoSearchListResponseByUser;
+import com.example.green.global.api.page.PageTemplate;
 
 public interface InfoService {
 	/**
 	 * 관리자 전체 Info 페이지 단위로 조회
 	 */
-	InfoSearchListResponseByAdmin getInfosForAdmin(int page, int size);
+	PageTemplate<InfoSearchResponseByAdmin> getInfosForAdmin(int page, int size);
 
 	/**
 	 * 관리자 Info 상세 페이지 조회

--- a/src/test/java/com/example/integration/info/InfoServiceIntTest.java
+++ b/src/test/java/com/example/integration/info/InfoServiceIntTest.java
@@ -88,7 +88,7 @@ class InfoServiceIntTest extends BaseIntegrationTest {
 
 				// then
 				assertThat(response.content()).isNotEmpty();
-				assertThat(response.page().totalPages()).isGreaterThan(0);
+				assertThat(response.totalPages()).isGreaterThan(0);
 				// Enum 타입이 String으로 변환되어 반환되는지 확인
 				assertThat(response.content().get(0).infoCategoryName()).isEqualTo(
 					infoEntity.getInfoCategory().getDescription());


### PR DESCRIPTION

## #️⃣ 연관된 이슈

> #239 

## 📝 작업 내용

* 정보공유글 페이지네이션 다른 모듈에서 사용하고 있는 PageTemplate으로 통일화
* PageRequest -> PageNation으로 변경
* 이에 따른 통합테스트, Repoistory 쿼리 추가

## 📷 스크린샷

> 이미지

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 명칭

### 📌 PR 진행 시 참고사항
- 리뷰어는 좋은 코드 방향을 제시하되, **수정을 강요하지 않습니다.**
- 좋은 코드를 발견하면 **칭찬과 격려를 아끼지 않습니다.**
- 리뷰는 Reviewer로 지정된 시점 기준으로 **3일 이내**에 진행해 주세요.
- Comment 작성 시 아래 Prefix를 사용해 주세요:
    - `P1`: 꼭 반영해 주세요 (Request Changes) – 이슈나 취약점 관련
    - `P2`: 반영을 고려해 주세요 (Comment) – 개선 의견
    - `P3`: 단순 제안 (Chore)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Admin info list now returns paginated results with metadata.
  - Supports page and size parameters; page numbering starts at 1.
  - Default page size is 10 (maximum 100); results ordered by newest first.

- Documentation
  - API docs updated to reflect paginated response, 1-based pagination, and parameter defaults/limits.

- Tests
  - Integration tests updated to align with new pagination fields in the response.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->