### PR TITLE
fix : [정보공유] 전시여부 ‘미전시’ : 데이터 아예 삭제됨 (#251)

### DIFF
--- a/src/main/java/com/example/green/domain/info/domain/InfoEntity.java
+++ b/src/main/java/com/example/green/domain/info/domain/InfoEntity.java
@@ -25,7 +25,7 @@ import lombok.NoArgsConstructor;
 @Entity
 @Table(name = "INFO")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@Where(clause = "deleted = false AND is_display = 'Y'")
+@Where(clause = "deleted = false ")//AND is_display = 'Y' 를 제외시킴
 public class InfoEntity extends BaseEntity {
 	@Id
 	@GeneratedValue(generator = "info-id-gen")

--- a/src/main/java/com/example/green/domain/info/repository/InfoRepository.java
+++ b/src/main/java/com/example/green/domain/info/repository/InfoRepository.java
@@ -17,5 +17,13 @@ public interface InfoRepository extends JpaRepository<InfoEntity, String> {
 
 	List<InfoEntity> findAllByOrderByCreatedDateDesc();
 
+	// 사용자단 전용: 전시중인 정보만 조회
+	@Query("""
+		SELECT i FROM InfoEntity i 
+		WHERE i.isDisplay = 'Y' 
+		ORDER BY i.createdDate DESC
+		""")
+	List<InfoEntity> findAllDisplayedInfoForUserOrderByCreatedDateDesc();
+
 }
 

--- a/src/main/java/com/example/green/domain/info/service/InfoServiceImpl.java
+++ b/src/main/java/com/example/green/domain/info/service/InfoServiceImpl.java
@@ -120,7 +120,8 @@ public class InfoServiceImpl implements InfoService {
 	@Override
 	@Transactional(readOnly = true)
 	public InfoSearchListResponseByUser getInfosForUser() {
-		List<InfoEntity> infoList = infoRepository.findAllByOrderByCreatedDateDesc();
+		// 전시중인(Y) 정보만 조회
+		List<InfoEntity> infoList = infoRepository.findAllDisplayedInfoForUserOrderByCreatedDateDesc();
 		return new InfoSearchListResponseByUser(
 			infoList.stream()
 				.map(InfoSearchResponseByUser::from)


### PR DESCRIPTION

## #️⃣ 연관된 이슈

> #251 

## 📝 작업 내용

* Entity의 전시 조건 삭제
* 사용자단의 Y만 조회하는 쿼리 추가

## 📷 스크린샷

> 이미지

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 명칭

### 📌 PR 진행 시 참고사항
- 리뷰어는 좋은 코드 방향을 제시하되, **수정을 강요하지 않습니다.**
- 좋은 코드를 발견하면 **칭찬과 격려를 아끼지 않습니다.**
- 리뷰는 Reviewer로 지정된 시점 기준으로 **3일 이내**에 진행해 주세요.
- Comment 작성 시 아래 Prefix를 사용해 주세요:
    - `P1`: 꼭 반영해 주세요 (Request Changes) – 이슈나 취약점 관련
    - `P2`: 반영을 고려해 주세요 (Comment) – 개선 의견
    - `P3`: 단순 제안 (Chore)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * User-facing info list now shows only items marked as visible.
  * Ensures the list is consistently ordered by newest first for easier browsing.
  * Prevents non-visible or removed items from appearing to end users.

* **Chores**
  * Internal filtering logic streamlined to better separate user-visible content from other records.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->