### PR TITLE
[feat/#245]  닉네임/이미지 독립적 수정 지원

### DIFF
--- a/src/main/java/com/example/green/domain/member/dto/ProfileUpdateRequestDto.java
+++ b/src/main/java/com/example/green/domain/member/dto/ProfileUpdateRequestDto.java
@@ -3,12 +3,14 @@ package com.example.green.domain.member.dto;
 import com.example.green.domain.member.entity.vo.Profile;
 
 import io.swagger.v3.oas.annotations.media.Schema;
-import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.AssertTrue;
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.springframework.util.StringUtils;
 
 @Getter
 @NoArgsConstructor
@@ -16,12 +18,16 @@ import lombok.NoArgsConstructor;
 @Schema(description = "프로필 업데이트 요청")
 public class ProfileUpdateRequestDto {
 
-	@NotBlank(message = "닉네임은 필수입니다.")
 	@Size(min = 2, max = 20, message = "닉네임은 2자 이상 20자 이하로 입력해주세요.")
 	@Pattern(regexp = "^[가-힣a-zA-Z0-9]+$", message = "닉네임은 한글, 영문, 숫자만 사용 가능합니다.")
-	@Schema(description = "닉네임", example = "새로운닉네임")
+	@Schema(description = "닉네임 (닉네임 또는 프로필 이미지 중 하나 이상 필수)", example = "새로운닉네임")
 	private String nickname;
 
-	@Schema(description = "프로필 이미지 URL", example = "https://s3.amazonaws.com/bucket/files/profile/uuid.jpg")
+	@Schema(description = "프로필 이미지 URL (닉네임 또는 프로필 이미지 중 하나 이상 필수)", example = "https://s3.amazonaws.com/bucket/files/profile/uuid.jpg")
 	private String profileImageUrl;
+
+	@AssertTrue(message = "닉네임 또는 프로필 이미지 중 하나 이상은 필수입니다.")
+	private boolean isAtLeastOneFieldPresent() {
+		return StringUtils.hasText(nickname) || StringUtils.hasText(profileImageUrl);
+	}
 } 


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> ex) close #Issue number

## 📝 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

  ### 변경 사항
  - 프로필 수정 API에서 닉네임과 프로필 이미지를 독립적으로 수정 가능하도록 개선
  - 기존: 닉네임 필수 입력
  - 변경: 닉네임 또는 프로필 이미지 중 최소 하나만 입력

  ### 변경 이유
  - 사용자가 프로필 사진만 변경하고 싶은 경우 닉네임 변경이 강제되는 문제 해결
  - 더 유연한 프로필 수정 경험 제공
변경 내용
  - `ProfileUpdateRequestDto`: `@NotBlank` 제거, `@AssertTrue` 검증 추가
  - 닉네임과 프로필 이미지 중 최소 하나는 필수로 검증
  - 단위 테스트 추가

## 📷 스크린샷

> 이미지

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 명칭

### 📌 PR 진행 시 참고사항
- 리뷰어는 좋은 코드 방향을 제시하되, **수정을 강요하지 않습니다.**
- 좋은 코드를 발견하면 **칭찬과 격려를 아끼지 않습니다.**
- 리뷰는 Reviewer로 지정된 시점 기준으로 **3일 이내**에 진행해 주세요.
- Comment 작성 시 아래 Prefix를 사용해 주세요:
    - `P1`: 꼭 반영해 주세요 (Request Changes) – 이슈나 취약점 관련
    - `P2`: 반영을 고려해 주세요 (Comment) – 개선 의견
    - `P3`: 단순 제안 (Chore)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Profile update now requires at least one of nickname or profile image. If provided, nickname must still meet length and format rules. Clear validation error message is shown when neither is supplied.
- Documentation
  - API documentation updated to reflect the new profile update requirement for nickname or profile image.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->