### PR TITLE
fix: 배송지 정보 수정 버그 해결 (#255)

### DIFF
--- a/src/main/java/com/example/green/domain/pointshop/delivery/controller/DeliveryAddressController.java
+++ b/src/main/java/com/example/green/domain/pointshop/delivery/controller/DeliveryAddressController.java
@@ -2,7 +2,6 @@ package com.example.green.domain.pointshop.delivery.controller;
 
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -48,15 +47,14 @@ public class DeliveryAddressController implements DeliveryAddressControllerDocs 
 		return ApiTemplate.ok(DeliveryAddressResponseMessage.DELIVERY_ADDRESS_ADD_SUCCESS, result);
 	}
 
-	@PutMapping("/{deliveryAddressId}")
+	@PutMapping("/me")
 	@AuthenticatedApi
 	public NoContent updateDeliveryAddress(
 		@Valid @RequestBody DeliveryAddressUpdateDto dto,
-		@PathVariable Long deliveryAddressId,
 		@AuthenticationPrincipal PrincipalDetails principalDetails
 	) {
 		Long recipientId = principalDetails.getMemberId();
-		DeliveryAddressUpdateCommand command = DeliveryAddressUpdateCommand.of(recipientId, deliveryAddressId, dto);
+		DeliveryAddressUpdateCommand command = DeliveryAddressUpdateCommand.of(recipientId, dto);
 		deliveryAddressService.updateSingleAddress(command);
 		return NoContent.ok(DeliveryAddressResponseMessage.DELIVERY_ADDRESS_UPDATE_SUCCESS);
 	}

--- a/src/main/java/com/example/green/domain/pointshop/delivery/controller/DeliveryAddressControllerDocs.java
+++ b/src/main/java/com/example/green/domain/pointshop/delivery/controller/DeliveryAddressControllerDocs.java
@@ -40,5 +40,5 @@ public interface DeliveryAddressControllerDocs {
 		content = @Content(schema = @Schema(implementation = ExceptionResponse.class))
 	)
 	NoContent updateDeliveryAddress(
-		DeliveryAddressUpdateDto dto, Long deliveryAddressId, PrincipalDetails principalDetails);
+		DeliveryAddressUpdateDto dto, PrincipalDetails principalDetails);
 }

--- a/src/main/java/com/example/green/domain/pointshop/delivery/service/DeliveryAddressService.java
+++ b/src/main/java/com/example/green/domain/pointshop/delivery/service/DeliveryAddressService.java
@@ -40,7 +40,7 @@ public class DeliveryAddressService {
 	public DeliveryResult getDeliveryAddressByRecipient(Long recipientId) {
 		return deliveryAddressRepository.findByRecipientId(recipientId)
 			.map(deliveryAddress -> DeliveryResult.of(
-				deliveryAddress.getRecipientId(),
+				deliveryAddress.getId(),
 				deliveryAddress.getRecipient(),
 				deliveryAddress.getAddress())
 			)
@@ -69,7 +69,7 @@ public class DeliveryAddressService {
 
 	@Transactional
 	public void updateSingleAddress(DeliveryAddressUpdateCommand command) {
-		DeliveryAddress deliveryAddress = deliveryAddressRepository.findById(command.deliveryAddressId())
+		DeliveryAddress deliveryAddress = deliveryAddressRepository.findByRecipientId(command.recipientId())
 			.orElseThrow(() -> new DeliveryAddressException(NOT_FOUND_DELIVERY_ADDRESS));
 
 		deliveryAddress.updateRecipient(command.recipient());

--- a/src/main/java/com/example/green/domain/pointshop/delivery/service/command/DeliveryAddressUpdateCommand.java
+++ b/src/main/java/com/example/green/domain/pointshop/delivery/service/command/DeliveryAddressUpdateCommand.java
@@ -6,16 +6,14 @@ import com.example.green.domain.pointshop.delivery.entity.vo.Recipient;
 
 public record DeliveryAddressUpdateCommand(
 	Long recipientId,
-	Long deliveryAddressId,
 	Recipient recipient,
 	Address address
 ) {
 
 	public static DeliveryAddressUpdateCommand of(
 		Long recipientId,
-		Long deliveryAddressId,
 		DeliveryAddressUpdateDto dto
 	) {
-		return new DeliveryAddressUpdateCommand(recipientId, deliveryAddressId, dto.toRecipient(), dto.toAddress());
+		return new DeliveryAddressUpdateCommand(recipientId, dto.toRecipient(), dto.toAddress());
 	}
 }

--- a/src/test/java/com/example/green/domain/pointshop/delivery/controller/DeliveryAddressRequest.java
+++ b/src/test/java/com/example/green/domain/pointshop/delivery/controller/DeliveryAddressRequest.java
@@ -31,7 +31,7 @@ public class DeliveryAddressRequest {
 			.given().log().all()
 			.contentType(MediaType.APPLICATION_JSON)
 			.body(dto)
-			.when().put("/api/deliveries/addresses/1")
+			.when().put("/api/deliveries/addresses/me")
 			.then().log().all()
 			.status(HttpStatus.OK)
 			.extract().as(new TypeRef<>() {

--- a/src/test/java/com/example/green/domain/pointshop/delivery/service/DeliveryAddressServiceTest.java
+++ b/src/test/java/com/example/green/domain/pointshop/delivery/service/DeliveryAddressServiceTest.java
@@ -15,12 +15,12 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import com.example.green.domain.pointshop.delivery.entity.DeliveryAddress;
 import com.example.green.domain.pointshop.delivery.entity.vo.Address;
 import com.example.green.domain.pointshop.delivery.entity.vo.Recipient;
-import com.example.green.domain.pointshop.order.entity.vo.DeliveryAddressSnapshot;
 import com.example.green.domain.pointshop.delivery.exception.DeliveryAddressException;
 import com.example.green.domain.pointshop.delivery.repository.DeliveryAddressRepository;
 import com.example.green.domain.pointshop.delivery.service.command.DeliveryAddressCreateCommand;
 import com.example.green.domain.pointshop.delivery.service.command.DeliveryAddressUpdateCommand;
 import com.example.green.domain.pointshop.delivery.service.result.DeliveryResult;
+import com.example.green.domain.pointshop.order.entity.vo.DeliveryAddressSnapshot;
 
 @ExtendWith(MockitoExtension.class)
 class DeliveryAddressServiceTest {
@@ -62,9 +62,12 @@ class DeliveryAddressServiceTest {
 	@Test
 	void 기존_배송지_정보가_있다면_배송지_조회에_성공한다() {
 		// given
+		DeliveryAddress mockDeliveryAddress = mock(DeliveryAddress.class);
 		Recipient recipient = Recipient.of("이름", "010-1234-5678");
 		Address address = Address.of("도로명", "상세주소", "12345");
-		DeliveryAddress mockDeliveryAddress = DeliveryAddress.create(1L, recipient, address);
+		when(mockDeliveryAddress.getId()).thenReturn(1L);
+		when(mockDeliveryAddress.getRecipient()).thenReturn(recipient);
+		when(mockDeliveryAddress.getAddress()).thenReturn(address);
 		when(deliveryAddressRepository.findByRecipientId(anyLong())).thenReturn(Optional.of(mockDeliveryAddress));
 		DeliveryResult deliveryResult = DeliveryResult.of(1L, recipient, address);
 
@@ -135,9 +138,8 @@ class DeliveryAddressServiceTest {
 	void 배송지_수정_커맨드가_발생하면_배송지_도메인의_수정_메서드를_호출한다() {
 		// given
 		DeliveryAddress mock = mock(DeliveryAddress.class);
-		when(deliveryAddressRepository.findById(anyLong())).thenReturn(Optional.of(mock));
+		when(deliveryAddressRepository.findByRecipientId(anyLong())).thenReturn(Optional.of(mock));
 		DeliveryAddressUpdateCommand command = new DeliveryAddressUpdateCommand(
-			1L,
 			1L,
 			Recipient.of("이름", "010-1234-5678"),
 			Address.of("도로명", "상세", "12345"));


### PR DESCRIPTION
## #️⃣ 연관된 이슈

close #255 

## 📝 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

## 📷 스크린샷

> 이미지

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 명칭

### 📌 PR 진행 시 참고사항
- 리뷰어는 좋은 코드 방향을 제시하되, **수정을 강요하지 않습니다.**
- 좋은 코드를 발견하면 **칭찬과 격려를 아끼지 않습니다.**
- 리뷰는 Reviewer로 지정된 시점 기준으로 **3일 이내**에 진행해 주세요.
- Comment 작성 시 아래 Prefix를 사용해 주세요:
    - `P1`: 꼭 반영해 주세요 (Request Changes) – 이슈나 취약점 관련
    - `P2`: 반영을 고려해 주세요 (Comment) – 개선 의견
    - `P3`: 단순 제안 (Chore)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Simplified delivery address updates: use PUT /api/deliveries/addresses/me. No address ID needed; it applies to the signed-in user. Response format and validation remain the same.
- Documentation
  - API reference updated to reflect the new endpoint and parameters.
- Tests
  - Test suite updated to cover the new path and user-based lookup behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->