### PR TITLE
fix: 컨트롤러 path 일관성 유지 및 dto validation 추가 (#259)

### DIFF
--- a/src/main/java/com/example/green/domain/challenge/controller/command/AdminPersonalChallengeCommandController.java
+++ b/src/main/java/com/example/green/domain/challenge/controller/command/AdminPersonalChallengeCommandController.java
@@ -49,7 +49,7 @@ public class AdminPersonalChallengeCommandController implements AdminPersonalCha
 		return NoContent.ok(AdminChallengeResponseMessage.CHALLENGE_SHOW);
 	}
 
-	@PatchMapping("/{challengeId}/invisibility")
+	@PatchMapping("/{challengeId}/hide")
 	public NoContent hide(@PathVariable Long challengeId) {
 		challengeService.hide(challengeId);
 		return NoContent.ok(AdminChallengeResponseMessage.CHALLENGE_HIDE);

--- a/src/main/java/com/example/green/domain/challenge/controller/command/AdminPersonalChallengeCommandController.java
+++ b/src/main/java/com/example/green/domain/challenge/controller/command/AdminPersonalChallengeCommandController.java
@@ -49,8 +49,14 @@ public class AdminPersonalChallengeCommandController implements AdminPersonalCha
 		return NoContent.ok(AdminChallengeResponseMessage.CHALLENGE_SHOW);
 	}
 
-	@PatchMapping("/{challengeId}/hide")
+	@PatchMapping("/{challengeId}/invisibility")
 	public NoContent hide(@PathVariable Long challengeId) {
+		challengeService.hide(challengeId);
+		return NoContent.ok(AdminChallengeResponseMessage.CHALLENGE_HIDE);
+	}
+
+	@PatchMapping("/{challengeId}/hide")
+	public NoContent hideV2(@PathVariable Long challengeId) {
 		challengeService.hide(challengeId);
 		return NoContent.ok(AdminChallengeResponseMessage.CHALLENGE_HIDE);
 	}

--- a/src/main/java/com/example/green/domain/challenge/controller/command/docs/AdminPersonalChallengeCommandControllerDocs.java
+++ b/src/main/java/com/example/green/domain/challenge/controller/command/docs/AdminPersonalChallengeCommandControllerDocs.java
@@ -56,4 +56,14 @@ public interface AdminPersonalChallengeCommandControllerDocs {
 		@Parameter(name = "challengeId", description = "챌린지 ID", in = PATH, required = true, example = "1")
 		Long challengeId
 	);
+
+	@Operation(summary = "개인 챌린지 미전시 V2 (SB에서 안보임)", description = "개인 챌린지를 미전시 상태로 변경합니다.")
+	@ApiErrorStandard
+	@ApiResponse(responseCode = "200", description = "전시 상태 변경 성공", useReturnTypeSchema = true)
+	@ApiResponse(responseCode = "403", description = "관리자 권한이 필요합니다.",
+		content = @Content(schema = @Schema(implementation = ExceptionResponse.class)))
+	NoContent hideV2(
+		@Parameter(name = "challengeId", description = "챌린지 ID", in = PATH, required = true, example = "1")
+		Long challengeId
+	);
 }

--- a/src/main/java/com/example/green/domain/challenge/controller/command/dto/AdminChallengeCreateDto.java
+++ b/src/main/java/com/example/green/domain/challenge/controller/command/dto/AdminChallengeCreateDto.java
@@ -12,9 +12,9 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import io.swagger.v3.oas.annotations.media.Schema;
-import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
 import jakarta.validation.constraints.Size;
 
 public record AdminChallengeCreateDto(
@@ -25,7 +25,7 @@ public record AdminChallengeCreateDto(
 
 	@Schema(description = "챌린지 포인트", example = "100", requiredMode = Schema.RequiredMode.REQUIRED)
 	@NotNull(message = "챌린지 포인트는 필수값입니다.")
-	@Min(value = 0, message = "챌린지 포인트는 0 이상이어야 합니다.")
+	@Positive(message = "챌린지 포인트는 양수이어야 합니다.")
 	BigDecimal challengePoint,
 
 	@Schema(description = "시작 일시", requiredMode = Schema.RequiredMode.REQUIRED)
@@ -37,10 +37,11 @@ public record AdminChallengeCreateDto(
 	LocalDate endDate,
 
 	@Schema(description = "챌린지 설명 및 참여방법", example = "매일 30분 이상 운동하기")
-	@NotNull
+	@NotNull(message = "챌린지 내용은 Null 일 수 없습니다.")
 	String challengeContent,
 
 	@Schema(description = "챌린지 이미지 URL", example = "https://example.com/challenge.jpg")
+	@NotBlank(message = "챌린지 이미지 URL은 필수값입니다.")
 	String challengeImageUrl,
 
 	@Schema(description = "디스플레이 여부")

--- a/src/main/java/com/example/green/domain/challenge/controller/command/dto/AdminChallengeUpdateDto.java
+++ b/src/main/java/com/example/green/domain/challenge/controller/command/dto/AdminChallengeUpdateDto.java
@@ -8,9 +8,9 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import io.swagger.v3.oas.annotations.media.Schema;
-import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
 import jakarta.validation.constraints.Size;
 
 @Schema(description = "어드민 챌린지 수정 요청")
@@ -22,7 +22,7 @@ public record AdminChallengeUpdateDto(
 
 	@Schema(description = "챌린지 포인트", example = "100", requiredMode = Schema.RequiredMode.REQUIRED)
 	@NotNull(message = "챌린지 포인트는 필수값입니다.")
-	@Min(value = 0, message = "챌린지 포인트는 0 이상이어야 합니다.")
+	@Positive(message = "챌린지 포인트는 양수이어야 합니다.")
 	BigDecimal challengePoint,
 
 	@Schema(description = "시작 일시", requiredMode = Schema.RequiredMode.REQUIRED)
@@ -34,6 +34,7 @@ public record AdminChallengeUpdateDto(
 	LocalDate endDate,
 
 	@Schema(description = "챌린지 설명 및 참여방법", example = "매일 30분 이상 운동하기")
+	@NotNull(message = "챌린지 내용은 Null 일 수 없습니다.")
 	String challengeContent,
 
 	@Schema(description = "챌린지 이미지 URL", example = "https://example.com/challenge-image.jpg")

--- a/src/main/java/com/example/green/domain/challenge/controller/command/dto/ChallengeGroupCreateDto.java
+++ b/src/main/java/com/example/green/domain/challenge/controller/command/dto/ChallengeGroupCreateDto.java
@@ -27,17 +27,21 @@ public record ChallengeGroupCreateDto(
 	String roadAddress,
 
 	@Schema(description = "상세 주소", example = "삼성동 빌딩 1층")
+	@NotBlank(message = "상세 주소는 필수값입니다.")
 	String detailAddress,
 
 	@Schema(description = "시군구", example = "강남구")
+	@NotBlank(message = "시군구 정보는 필수값입니다.")
 	String sigungu,
 
 	@Schema(description = "그룹 설명", example = "매주 화, 목 저녁 7시에 모여서 5km 러닝합니다.")
 	@Size(max = 500, message = "그룹 설명은 500자 이하여야 합니다.")
+	@NotBlank(message = "그룹 설명은 필수값입니다.")
 	String description,
 
 	@Schema(description = "오픈 채팅 URL", example = "https://open.kakao.com/o/abc123")
 	@Size(max = 500, message = "오픈 채팅 URL은 500자 이하여야 합니다.")
+	@NotBlank(message = "오픈 채팅 정보는 필수값입니다.")
 	String openChatUrl,
 
 	@Schema(description = "챌린지 활동 일자", requiredMode = Schema.RequiredMode.REQUIRED)

--- a/src/main/java/com/example/green/domain/challenge/controller/command/dto/ChallengeGroupUpdateDto.java
+++ b/src/main/java/com/example/green/domain/challenge/controller/command/dto/ChallengeGroupUpdateDto.java
@@ -26,17 +26,21 @@ public record ChallengeGroupUpdateDto(
 	String roadAddress,
 
 	@Schema(description = "상세 주소", example = "삼성동 빌딩 3층")
+	@NotBlank(message = "상세 주소는 필수값입니다.")
 	String detailAddress,
 
 	@Schema(description = "시군구 정보", example = "강남구")
+	@NotBlank(message = "시군구 정보는 필수값입니다.")
 	String sigungu,
 
 	@Schema(description = "그룹 설명", example = "매주 화, 목 저녁 7시에 모여서 5km 러닝합니다.")
 	@Size(max = 500, message = "그룹 설명은 500자 이하여야 합니다.")
+	@NotBlank(message = "그룹 설명은 필수값입니다.")
 	String description,
 
 	@Schema(description = "오픈 채팅 URL", example = "https://open.kakao.com/o/abc123")
 	@Size(max = 500, message = "오픈 채팅 URL은 500자 이하여야 합니다.")
+	@NotBlank(message = "오픈 채팅 정보는 필수값입니다.")
 	String openChatUrl,
 
 	@Schema(description = "챌린지 활동 일자", requiredMode = Schema.RequiredMode.REQUIRED)


### PR DESCRIPTION
## #️⃣ 연관된 이슈

close #259 

## 📝 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

## 📷 스크린샷

> 이미지

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 명칭

### 📌 PR 진행 시 참고사항
- 리뷰어는 좋은 코드 방향을 제시하되, **수정을 강요하지 않습니다.**
- 좋은 코드를 발견하면 **칭찬과 격려를 아끼지 않습니다.**
- 리뷰는 Reviewer로 지정된 시점 기준으로 **3일 이내**에 진행해 주세요.
- Comment 작성 시 아래 Prefix를 사용해 주세요:
    - `P1`: 꼭 반영해 주세요 (Request Changes) – 이슈나 취약점 관련
    - `P2`: 반영을 고려해 주세요 (Comment) – 개선 의견
    - `P3`: 단순 제안 (Chore)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Breaking Changes
  - challengePoint must be positive; 0 is no longer accepted in admin challenge create/update.

- Enhancements
  - Added an additional admin PATCH route to hide a personal challenge.
  - Validation tightened: challenge content cannot be null; image URL required on admin create.
  - Group challenges now reject blank detail address, sigungu, description, and open chat URL.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->