### PR TITLE
refactor: 관리자 회원 삭제 API  http method 변경

### DIFF
--- a/src/main/java/com/example/green/domain/member/controller/MemberAdminController.java
+++ b/src/main/java/com/example/green/domain/member/controller/MemberAdminController.java
@@ -5,14 +5,13 @@ import java.util.List;
 import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.example.green.domain.member.controller.docs.MemberManagementControllerDocs;
 import com.example.green.domain.member.controller.message.MemberResponseMessage;
-import com.example.green.domain.member.dto.admin.MemberDeleteRequestDto;
 import com.example.green.domain.member.dto.admin.MemberListRequestDto;
 import com.example.green.domain.member.dto.admin.MemberListResponseDto;
 import com.example.green.domain.member.dto.admin.WithdrawnMemberListResponseDto;
@@ -89,13 +88,13 @@ public class MemberAdminController implements MemberManagementControllerDocs {
 	}
 
 	@Override
-	@PostMapping("/delete")
-	public NoContent deleteMember(@RequestBody @Valid MemberDeleteRequestDto request) {
-		log.info("[ADMIN] 회원 강제 삭제 요청: memberKey={}", request.memberKey());
+	@DeleteMapping("/{memberKey}")
+	public NoContent deleteMember(@PathVariable String memberKey) {
+		log.info("[ADMIN] 회원 강제 삭제 요청: memberKey={}", memberKey);
 
-		memberAdminService.validateMemberExistsByMemberKey(request.memberKey());
+		memberAdminService.validateMemberExistsByMemberKey(memberKey);
 
-		memberAdminService.deleteMemberByMemberKey(request.memberKey());
+		memberAdminService.deleteMemberByMemberKey(memberKey);
 
 		return NoContent.ok(MemberResponseMessage.MEMBER_DELETED);
 	}

--- a/src/main/java/com/example/green/domain/member/controller/docs/MemberManagementControllerDocs.java
+++ b/src/main/java/com/example/green/domain/member/controller/docs/MemberManagementControllerDocs.java
@@ -1,6 +1,5 @@
 package com.example.green.domain.member.controller.docs;
 
-import com.example.green.domain.member.dto.admin.MemberDeleteRequestDto;
 import com.example.green.domain.member.dto.admin.MemberListRequestDto;
 import com.example.green.domain.member.dto.admin.MemberListResponseDto;
 import com.example.green.domain.member.dto.admin.WithdrawnMemberListResponseDto;
@@ -184,7 +183,7 @@ public interface MemberManagementControllerDocs {
 		)
 	})
 	@ApiErrorStandard
-	NoContent deleteMember(MemberDeleteRequestDto request);
+	NoContent deleteMember(String memberKey);
 
 	@Operation(summary = "사용자 별 포인트 조회 (ad_E01_001)", description = "사용자 별 포인트 조회를 합니다.")
 	@ApiResponses(value = {

--- a/src/test/java/com/example/green/domain/member/controller/MemberAdminControllerTest.java
+++ b/src/test/java/com/example/green/domain/member/controller/MemberAdminControllerTest.java
@@ -14,7 +14,6 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.http.HttpStatus;
-import org.springframework.http.MediaType;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 import com.example.green.domain.member.dto.admin.MemberListResponseDto;
@@ -96,14 +95,8 @@ class MemberAdminControllerTest extends BaseControllerUnitTest {
 
 		// when & then
 		given().log().all()
-			.contentType(MediaType.APPLICATION_JSON_VALUE)
-			.body("""
-				{
-				    "memberKey": "naver 123456789"
-				}
-				""")
 			.when()
-			.post("/api/admin/members/delete")
+			.delete("/api/admin/members/{memberKey}", memberKey)
 			.then().log().all()
 			.status(HttpStatus.OK)
 			.body("success", equalTo(true))
@@ -143,14 +136,8 @@ class MemberAdminControllerTest extends BaseControllerUnitTest {
 
 		// when & then
 		given().log().all()
-			.contentType(MediaType.APPLICATION_JSON_VALUE)
-			.body("""
-				{
-				    "memberKey": "invalid_username"
-				}
-				""")
 			.when()
-			.post("/api/admin/members/delete")
+			.delete("/api/admin/members/{memberKey}", memberKey)
 			.then().log().all()
 			.status(HttpStatus.INTERNAL_SERVER_ERROR);
 


### PR DESCRIPTION
- POST /api/admin/members/delete -> DELETE /api/admin/members/{memberKey}
- Request Body 대신 Path Variable 사용
- 불필요한 DTO 및 import 제거

## #️⃣ 연관된 이슈

> ex) close #Issue number

## 📝 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

## 📷 스크린샷

> 이미지

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 명칭

### 📌 PR 진행 시 참고사항
- 리뷰어는 좋은 코드 방향을 제시하되, **수정을 강요하지 않습니다.**
- 좋은 코드를 발견하면 **칭찬과 격려를 아끼지 않습니다.**
- 리뷰는 Reviewer로 지정된 시점 기준으로 **3일 이내**에 진행해 주세요.
- Comment 작성 시 아래 Prefix를 사용해 주세요:
    - `P1`: 꼭 반영해 주세요 (Request Changes) – 이슈나 취약점 관련
    - `P2`: 반영을 고려해 주세요 (Comment) – 개선 의견
    - `P3`: 단순 제안 (Chore)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - Member deletion now uses DELETE /api/admin/members/{memberKey} instead of POST /api/admin/members/delete with a request body.
- Documentation
  - Updated API docs to reflect the new DELETE endpoint and path parameter.
- Tests
  - Updated controller tests to call the DELETE endpoint with a path parameter; removed JSON payload usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->