### PR TITLE
fix: 개인 챌린지 display에 따른 조회 버그 해결

### DIFF
--- a/src/main/java/com/example/green/domain/challenge/infra/querydsl/predicates/PersonalChallengePredicates.java
+++ b/src/main/java/com/example/green/domain/challenge/infra/querydsl/predicates/PersonalChallengePredicates.java
@@ -5,6 +5,7 @@ import static com.example.green.domain.challenge.entity.challenge.QPersonalChall
 
 import java.time.LocalDateTime;
 
+import com.example.green.domain.challenge.entity.challenge.vo.ChallengeDisplayStatus;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.JPAExpressions;
 
@@ -24,7 +25,9 @@ public class PersonalChallengePredicates {
 
 	public static BooleanExpression activeChallengeCondition(Long cursor, LocalDateTime now) {
 		BooleanExpression expression = personalChallenge.beginDate.loe(now.toLocalDate())
-			.and(personalChallenge.endDate.goe(now.toLocalDate()));
+			.and(personalChallenge.endDate.goe(now.toLocalDate()))
+			.and(personalChallenge.displayStatus.eq(ChallengeDisplayStatus.VISIBLE));
+		
 		if (cursor == null) {
 			return expression;
 		}


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> ex) close #Issue number

## 📝 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

## 📷 스크린샷

> 이미지

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 명칭

### 📌 PR 진행 시 참고사항
- 리뷰어는 좋은 코드 방향을 제시하되, **수정을 강요하지 않습니다.**
- 좋은 코드를 발견하면 **칭찬과 격려를 아끼지 않습니다.**
- 리뷰는 Reviewer로 지정된 시점 기준으로 **3일 이내**에 진행해 주세요.
- Comment 작성 시 아래 Prefix를 사용해 주세요:
    - `P1`: 꼭 반영해 주세요 (Request Changes) – 이슈나 취약점 관련
    - `P2`: 반영을 고려해 주세요 (Comment) – 개선 의견
    - `P3`: 단순 제안 (Chore)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Active personal challenges now respect visibility settings, ensuring only visible challenges appear in lists, dashboards, and counts during their active date range.
  * Hidden or unpublished challenges are excluded from active views, reducing confusion and mismatched totals.
  * Improves consistency across screens that show “active” personal challenges, including any summaries or notifications that rely on active challenge status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->