### PR TITLE
[feat: 회원 탈퇴 사유 다중 선택 기능 구현]

### DIFF
--- a/src/main/java/com/example/green/domain/member/controller/MemberController.java
+++ b/src/main/java/com/example/green/domain/member/controller/MemberController.java
@@ -112,13 +112,13 @@ public class MemberController implements MemberControllerDocs {
 		
 		String memberKey = currentUser.getUsername();
 
-		log.info("[WITHDRAW] 회원 탈퇴 요청 - memberKey: {}, reasonType: {}", 
-				 memberKey, withdrawRequest.reasonType());
+		log.info("[WITHDRAW] 회원 탈퇴 요청 - memberKey: {}, reasonTypes: {}", 
+				 memberKey, withdrawRequest.reasonTypes());
 
 		withdrawService.withdrawMemberWithReason(memberKey, withdrawRequest);
 
-		log.info("[WITHDRAW] 회원 탈퇴 완료 - memberKey: {}, reasonType: {}", 
-				 memberKey, withdrawRequest.reasonType());
+		log.info("[WITHDRAW] 회원 탈퇴 완료 - memberKey: {}, reasonTypes: {}", 
+				 memberKey, withdrawRequest.reasonTypes());
 		return ResponseEntity.ok().build();
 	}
 }

--- a/src/main/java/com/example/green/domain/member/controller/docs/MemberControllerDocs.java
+++ b/src/main/java/com/example/green/domain/member/controller/docs/MemberControllerDocs.java
@@ -173,21 +173,31 @@ public interface MemberControllerDocs {
                 examples = {
                     @ExampleObject(
                         name = "일반 사유로 탈퇴",
-                        summary = "미리 정의된 사유 (customReason 무시됨)",
+                        summary = "미리 정의된 사유들 선택 (최소 1개, 최대 5개)",
                         value = """
                             {
-                                "reasonType": "SERVICE_DISSATISFACTION",
+                                "reasonTypes": ["SERVICE_DISSATISFACTION", "PRIVACY_CONCERN"],
                                 "customReason": null
                             }
                             """
                     ),
                     @ExampleObject(
-                        name = "기타 사유로 탈퇴",
-                        summary = "OTHER 선택 시 customReason 필수",
+                        name = "기타 사유 포함 탈퇴",
+                        summary = "OTHER 포함 시 customReason 필수",
                         value = """
                             {
-                                "reasonType": "OTHER",
+                                "reasonTypes": ["SERVICE_DISSATISFACTION", "OTHER"],
                                 "customReason": "원하는 기능이 없어서 탈퇴합니다."
+                            }
+                            """
+                    ),
+                    @ExampleObject(
+                        name = "다중 사유 선택",
+                        summary = "여러 사유 동시 선택 가능",
+                        value = """
+                            {
+                                "reasonTypes": ["SERVICE_DISSATISFACTION", "POLICY_DISAGREEMENT", "PRIVACY_CONCERN"],
+                                "customReason": null
                             }
                             """
                     )

--- a/src/main/java/com/example/green/domain/member/dto/WithdrawRequestDto.java
+++ b/src/main/java/com/example/green/domain/member/dto/WithdrawRequestDto.java
@@ -1,34 +1,38 @@
 package com.example.green.domain.member.dto;
 
+import java.util.List;
+
 import com.example.green.domain.member.entity.enums.WithdrawReasonType;
 
+import io.swagger.v3.oas.annotations.media.ArraySchema;
 import io.swagger.v3.oas.annotations.media.Schema;
-import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.Size;
 
 
 @Schema(description = "회원 탈퇴 요청")
 public record WithdrawRequestDto(
     
-    @NotNull(message = "탈퇴 사유를 선택해주세요.")
-    @Schema(
-        description = "탈퇴 사유 타입 (단일 선택)", 
-        example = "SERVICE_DISSATISFACTION",
-        type = "string",
-        allowableValues = {
-            "SERVICE_DISSATISFACTION", 
-            "POLICY_DISAGREEMENT", 
-            "PRIVACY_CONCERN", 
-            "PRIVACY_PROTECTION", 
-            "OTHER"
-        },
-        requiredMode = Schema.RequiredMode.REQUIRED
+    @NotEmpty(message = "탈퇴 사유를 최소 1개 이상 선택해주세요.")
+    @Size(min = 1, max = 5, message = "탈퇴 사유는 최소 1개, 최대 5개까지 선택 가능합니다.")
+    @ArraySchema(
+        schema = @Schema(
+            description = "탈퇴 사유 타입 (다중 선택, 최소 1개 ~ 최대 5개)",
+            implementation = WithdrawReasonType.class,
+            allowableValues = {
+                "SERVICE_DISSATISFACTION", 
+                "POLICY_DISAGREEMENT", 
+                "PRIVACY_CONCERN", 
+                "PRIVACY_PROTECTION", 
+                "OTHER"
+            }
+        )
     )
-    WithdrawReasonType reasonType,
+    List<WithdrawReasonType> reasonTypes,
     
     @Size(max = 1000, message = "탈퇴 사유는 1000자 이내로 입력해주세요.")
     @Schema(
-        description = "상세 탈퇴 사유 (reasonType이 'OTHER'인 경우 필수 입력)", 
+        description = "상세 탈퇴 사유 (reasonTypes에 'OTHER'가 포함된 경우 필수 입력)", 
         example = "챌린지 기능이 부족해서 탈퇴합니다.",
         nullable = true
     )
@@ -43,5 +47,9 @@ public record WithdrawRequestDto(
 
     public String getCleanCustomReason() {
         return hasCustomReason() ? customReason.trim() : null;
+    }
+    
+    public boolean containsOtherReason() {
+        return reasonTypes != null && reasonTypes.contains(WithdrawReasonType.OTHER);
     }
 } 

--- a/src/main/java/com/example/green/domain/member/entity/WithdrawReason.java
+++ b/src/main/java/com/example/green/domain/member/entity/WithdrawReason.java
@@ -58,6 +58,10 @@ public class WithdrawReason extends BaseEntity {
             .customReason(customReason)
             .build();
     }
+    
+    public static WithdrawReason create(Member member, WithdrawReasonType reasonType) {
+        return create(member, reasonType, null);
+    }
 
 
     public boolean hasCustomReason() {

--- a/src/main/java/com/example/green/domain/member/exception/MemberExceptionMessage.java
+++ b/src/main/java/com/example/green/domain/member/exception/MemberExceptionMessage.java
@@ -20,7 +20,8 @@ public enum MemberExceptionMessage implements ExceptionMessage {
 	MEMBER_NICKNAME_DUPLICATE(CONFLICT, "이미 사용 중인 닉네임입니다."),
 	MEMBER_ALREADY_WITHDRAWN(BAD_REQUEST, "이미 탈퇴한 회원입니다."),
 	MEMBER_WITHDRAW_FAILED(INTERNAL_SERVER_ERROR, "회원 탈퇴 처리에 실패했습니다."),
-	WITHDRAW_CUSTOM_REASON_REQUIRED(BAD_REQUEST, "기타 사유 선택 시 상세 사유를 입력해주세요.")
+	WITHDRAW_CUSTOM_REASON_REQUIRED(BAD_REQUEST, "기타 사유 선택 시 상세 사유를 입력해주세요."),
+	DUPLICATE_WITHDRAW_REASONS(BAD_REQUEST, "중복된 탈퇴 사유를 선택할 수 없습니다.")
 	;
 
 	private final HttpStatus httpStatus;

--- a/src/test/java/com/example/integration/auth/WithdrawMemberIntegrationTest.java
+++ b/src/test/java/com/example/integration/auth/WithdrawMemberIntegrationTest.java
@@ -4,6 +4,8 @@ import static org.assertj.core.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
 import java.time.LocalDateTime;
+import java.util.Arrays;
+import java.util.List;
 import java.util.Optional;
 
 import org.junit.jupiter.api.AfterEach;
@@ -77,8 +79,11 @@ class WithdrawMemberIntegrationTest extends BaseIntegrationTest {
 		// given
 		String memberKey = testMember.getMemberKey();
 		Long memberId = testMember.getId();
+		List<WithdrawReasonType> reasonTypes = Arrays.asList(
+			WithdrawReasonType.SERVICE_DISSATISFACTION
+		);
 		WithdrawRequestDto request = new WithdrawRequestDto(
-			WithdrawReasonType.SERVICE_DISSATISFACTION,
+			reasonTypes,
 			null
 		);
 
@@ -111,8 +116,11 @@ class WithdrawMemberIntegrationTest extends BaseIntegrationTest {
 	void withdrawMemberWithReason_WithNonExistentMember_ShouldThrowException() {
 		// given
 		String nonExistentMemberKey = "nonexistent 123456";
+		List<WithdrawReasonType> reasonTypes = Arrays.asList(
+			WithdrawReasonType.PRIVACY_CONCERN
+		);
 		WithdrawRequestDto request = new WithdrawRequestDto(
-			WithdrawReasonType.PRIVACY_CONCERN,
+			reasonTypes,
 			null
 		);
 
@@ -128,8 +136,11 @@ class WithdrawMemberIntegrationTest extends BaseIntegrationTest {
 		// given
 		String memberKey = testMember.getMemberKey();
 		String profileImageUrl = testMember.getProfile().getProfileImageUrl();
+		List<WithdrawReasonType> reasonTypes = Arrays.asList(
+			WithdrawReasonType.PRIVACY_PROTECTION
+		);
 		WithdrawRequestDto request = new WithdrawRequestDto(
-			            WithdrawReasonType.PRIVACY_PROTECTION,
+			reasonTypes,
 			null
 		);
 
@@ -155,8 +166,11 @@ class WithdrawMemberIntegrationTest extends BaseIntegrationTest {
 	void withdrawMemberWithReason_OtherReasonWithoutCustomReason_ShouldThrowException() {
 		// given
 		String memberKey = testMember.getMemberKey();
+		List<WithdrawReasonType> reasonTypes = Arrays.asList(
+			WithdrawReasonType.OTHER
+		);
 		WithdrawRequestDto request = new WithdrawRequestDto(
-			WithdrawReasonType.OTHER,
+			reasonTypes,
 			null // 기타 사유인데 상세 사유 없음
 		);
 

--- a/src/test/java/com/example/integration/member/WithdrawMemberWithReasonIntegrationTest.java
+++ b/src/test/java/com/example/integration/member/WithdrawMemberWithReasonIntegrationTest.java
@@ -4,6 +4,8 @@ import static org.assertj.core.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
 import java.time.LocalDateTime;
+import java.util.Arrays;
+import java.util.List;
 import java.util.Optional;
 
 import org.junit.jupiter.api.AfterEach;
@@ -74,8 +76,11 @@ class WithdrawMemberWithReasonIntegrationTest extends BaseIntegrationTest {
         // given
         String memberKey = testMember.getMemberKey();
         Long memberId = testMember.getId();
+        List<WithdrawReasonType> reasonTypes = Arrays.asList(
+            WithdrawReasonType.SERVICE_DISSATISFACTION
+        );
         WithdrawRequestDto request = new WithdrawRequestDto(
-            WithdrawReasonType.SERVICE_DISSATISFACTION,
+            reasonTypes,
             null  // OTHER 외에는 customReason 무시됨
         );
 
@@ -104,8 +109,11 @@ class WithdrawMemberWithReasonIntegrationTest extends BaseIntegrationTest {
     void withdrawMemberWithReason_WithOtherReason_ShouldSucceed() {
         // given
         String memberKey = testMember.getMemberKey();
+        List<WithdrawReasonType> reasonTypes = Arrays.asList(
+            WithdrawReasonType.OTHER
+        );
         WithdrawRequestDto request = new WithdrawRequestDto(
-            WithdrawReasonType.OTHER,
+            reasonTypes,
             "개인적인 사유로 인해 탈퇴합니다."
         );
 
@@ -128,8 +136,11 @@ class WithdrawMemberWithReasonIntegrationTest extends BaseIntegrationTest {
     void withdrawMemberWithReason_WithoutCustomReason_ShouldSucceed() {
         // given
         String memberKey = testMember.getMemberKey();
+        List<WithdrawReasonType> reasonTypes = Arrays.asList(
+            WithdrawReasonType.PRIVACY_CONCERN
+        );
         WithdrawRequestDto request = new WithdrawRequestDto(
-            WithdrawReasonType.PRIVACY_CONCERN,
+            reasonTypes,
             null
         );
 
@@ -153,8 +164,11 @@ class WithdrawMemberWithReasonIntegrationTest extends BaseIntegrationTest {
         // given
         String memberKey = testMember.getMemberKey();
         String profileImageUrl = testMember.getProfile().getProfileImageUrl();
+        List<WithdrawReasonType> reasonTypes = Arrays.asList(
+            WithdrawReasonType.PRIVACY_PROTECTION
+        );
         WithdrawRequestDto request = new WithdrawRequestDto(
-            WithdrawReasonType.PRIVACY_PROTECTION,
+            reasonTypes,
             null
         );
 


### PR DESCRIPTION
- WithdrawRequestDto: reasonType → reasonTypes (List) 변경
- 최소 1개, 최대 5개까지 탈퇴 사유 선택 가능
- 중복 사유 선택 방지 검증 추가
- OTHER 선택 시 customReason 필수 입력 유지
- 각 사유별로 WithdrawReason 엔티티 개별 저장
- 테스트 코드 및 API 문서 업데이트

## #️⃣ 연관된 이슈

> ex) close #Issue number

## 📝 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

## 📷 스크린샷

> 이미지

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 명칭

### 📌 PR 진행 시 참고사항
- 리뷰어는 좋은 코드 방향을 제시하되, **수정을 강요하지 않습니다.**
- 좋은 코드를 발견하면 **칭찬과 격려를 아끼지 않습니다.**
- 리뷰는 Reviewer로 지정된 시점 기준으로 **3일 이내**에 진행해 주세요.
- Comment 작성 시 아래 Prefix를 사용해 주세요:
    - `P1`: 꼭 반영해 주세요 (Request Changes) – 이슈나 취약점 관련
    - `P2`: 반영을 고려해 주세요 (Comment) – 개선 의견
    - `P3`: 단순 제안 (Chore)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Withdrawal now supports selecting multiple reasons (1–5) via a reasons list.
  - Enforces custom reason when “OTHER” is selected.
  - Prevents submitting duplicate reasons with a clear validation error.

- Documentation
  - API examples updated to use a reasons array and include multi-select scenarios, including “OTHER” guidance.

- Error Messages
  - Added a specific error message for duplicate withdrawal reasons.

- Tests
  - Test suite updated to cover multi-reason flows and validation rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->