### PR TITLE
fix: FileService null 처리 개선으로 프로필 이미지 기본값 설정 오류 해결

### DIFF
--- a/src/main/java/com/example/green/domain/file/service/FileService.java
+++ b/src/main/java/com/example/green/domain/file/service/FileService.java
@@ -37,17 +37,26 @@ public class FileService {
 	}
 
 	public void confirmUsingImage(String imageUrl) {
+		if (imageUrl == null || imageUrl.trim().isEmpty()) {
+			return;
+		}
 		FileEntity fileEntity = getFileEntityFromImageUrl(imageUrl);
 		fileEntity.markAsPermanent();
 	}
 
 	public void unUseImage(String imageUrl) {
+		if (imageUrl == null || imageUrl.trim().isEmpty()) {
+			return;
+		}
 		FileEntity fileEntity = getFileEntityFromImageUrl(imageUrl);
 		fileEntity.markDeleted();
 	}
 
 	public void swapImage(String beforeImageUrl, String afterImageUrl) {
-		if (beforeImageUrl.equals(afterImageUrl)) {
+		if (beforeImageUrl == null && afterImageUrl == null) {
+			return;
+		}
+		if (beforeImageUrl != null && beforeImageUrl.equals(afterImageUrl)) {
 			return;
 		}
 		unUseImage(beforeImageUrl);


### PR DESCRIPTION
- confirmUsingImage, unUseImage 메서드에 null/빈 문자열 체크 추가
- swapImage 메서드 NullPointerException 방지를 위한 null 체크 순서 수정
- 프로필 이미지를 null로 설정 시 기본 이미지로 변경되도록 수정

## #️⃣ 연관된 이슈

> ex) close #Issue number

## 📝 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

## 📷 스크린샷

> 이미지

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 명칭

### 📌 PR 진행 시 참고사항
- 리뷰어는 좋은 코드 방향을 제시하되, **수정을 강요하지 않습니다.**
- 좋은 코드를 발견하면 **칭찬과 격려를 아끼지 않습니다.**
- 리뷰는 Reviewer로 지정된 시점 기준으로 **3일 이내**에 진행해 주세요.
- Comment 작성 시 아래 Prefix를 사용해 주세요:
    - `P1`: 꼭 반영해 주세요 (Request Changes) – 이슈나 취약점 관련
    - `P2`: 반영을 고려해 주세요 (Comment) – 개선 의견
    - `P3`: 단순 제안 (Chore)
