### PR TITLE
fix: OAuth 회원가입 시 닉네임 검증 오류 수정

### DIFF
--- a/src/main/java/com/example/green/domain/member/entity/Member.java
+++ b/src/main/java/com/example/green/domain/member/entity/Member.java
@@ -2,6 +2,8 @@ package com.example.green.domain.member.entity;
 
 import java.time.LocalDateTime;
 
+import org.springframework.util.StringUtils;
+
 import com.example.green.domain.common.BaseEntity;
 import com.example.green.domain.member.entity.enums.MemberRole;
 import com.example.green.domain.member.entity.enums.MemberStatus;
@@ -67,12 +69,20 @@ public class Member extends BaseEntity {
 
 	private LocalDateTime lastLoginAt;
 
-	private Member(String memberKey, String name, String email) {
+	private Member(String memberKey, String name, String email, String nickname) {
 		this.memberKey = memberKey;
 		this.name = name;
 		this.email = email;
+		// 전달받은 nickname 사용, 없으면 임시 닉네임 생성 (최대 20자)
+		String actualNickname;
+		if (StringUtils.hasText(nickname)) {
+			actualNickname = nickname;
+		} else {
+			// 랜덤 6자리 숫자로 임시 닉네임 생성 (예: user123456)
+			actualNickname = "user" + String.format("%06d", (int)(Math.random() * 1000000));
+		}
 		this.profile = Profile.builder()
-			.nickname(name)
+			.nickname(actualNickname)
 			.profileImageUrl(null)
 			.build();
 		this.status = MemberStatus.NORMAL;
@@ -81,7 +91,11 @@ public class Member extends BaseEntity {
 	}
 
 	public static Member create(String memberKey, String name, String email) {
-		return new Member(memberKey, name, email);
+		return new Member(memberKey, name, email, null);
+	}
+	
+	public static Member create(String memberKey, String name, String email, String nickname) {
+		return new Member(memberKey, name, email, nickname);
 	}
 
 	public void updateOAuth2Info(String name, String email) {

--- a/src/main/java/com/example/green/domain/member/entity/vo/Profile.java
+++ b/src/main/java/com/example/green/domain/member/entity/vo/Profile.java
@@ -81,7 +81,7 @@ public class Profile {
 		
 		// 공백 검사 (정책: 공백 허용하지 않음 - 앞뒤 및 중간 공백 모두 금지)
 		if (nickname.contains(" ") || !nickname.equals(nickname.trim())) {
-			throw new BusinessException(MemberExceptionMessage.MEMBER_NICKNAME_INVALID);
+			throw new BusinessException(MemberExceptionMessage.MEMBER_NICKNAME_CONTAINS_SPACE);
 		}
 		
 		// 길이 검사 (정책: 최소 2자, 최대 20자)
@@ -91,7 +91,7 @@ public class Profile {
 		
 		// 허용 문자 검사 (정책: 한글, 영문, 숫자만 허용)
 		if (!nickname.matches("^[가-힣a-zA-Z0-9]+$")) {
-			throw new BusinessException(MemberExceptionMessage.MEMBER_NICKNAME_INVALID);
+			throw new BusinessException(MemberExceptionMessage.MEMBER_NICKNAME_INVALID_CHARACTER);
 		}
 	}
 }

--- a/src/main/java/com/example/green/domain/member/exception/MemberExceptionMessage.java
+++ b/src/main/java/com/example/green/domain/member/exception/MemberExceptionMessage.java
@@ -17,6 +17,8 @@ public enum MemberExceptionMessage implements ExceptionMessage {
 	MEMBER_PROFILE_UPDATE_FAILED(INTERNAL_SERVER_ERROR, "프로필 업데이트에 실패했습니다."),
 	MEMBER_NICKNAME_REQUIRED(BAD_REQUEST, "닉네임은 필수입니다."),
 	MEMBER_NICKNAME_INVALID(BAD_REQUEST, "닉네임은 2자 이상 20자 이하여야 합니다."),
+	MEMBER_NICKNAME_CONTAINS_SPACE(BAD_REQUEST, "닉네임에 공백을 포함할 수 없습니다."),
+	MEMBER_NICKNAME_INVALID_CHARACTER(BAD_REQUEST, "닉네임은 한글, 영문, 숫자만 사용 가능합니다."),
 	MEMBER_NICKNAME_DUPLICATE(CONFLICT, "이미 사용 중인 닉네임입니다."),
 	MEMBER_ALREADY_WITHDRAWN(BAD_REQUEST, "이미 탈퇴한 회원입니다."),
 	MEMBER_WITHDRAW_FAILED(INTERNAL_SERVER_ERROR, "회원 탈퇴 처리에 실패했습니다."),

--- a/src/main/java/com/example/green/domain/member/service/MemberService.java
+++ b/src/main/java/com/example/green/domain/member/service/MemberService.java
@@ -119,7 +119,10 @@ public class MemberService {
 	private String createNewMember(String memberKey, String name, String email, String nickname,
 		String profileImageUrl) {
 		try {
-			Member member = Member.create(memberKey, name, email);
+			// nickname이 있으면 새로운 create 메서드 사용
+			Member member = StringUtils.hasText(nickname) 
+				? Member.create(memberKey, name, email, nickname)
+				: Member.create(memberKey, name, email);
 
 			if (!StringUtils.hasText(profileImageUrl)) {
 				profileImageUrl = systemFileConfig.getDefaultProfileImageUrl();


### PR DESCRIPTION
- Member 생성자에 nickname 파라미터 추가하여 사용자 입력 닉네임 우선 사용
- OAuth provider의 name 대신 사용자가 입력한 닉네임으로 프로필 생성
- 닉네임 검증 에러 메시지 세분화 (공백, 특수문자 구분)
- 닉네임 미입력 시 임시 닉네임(user + 6자리 랜덤) 자동 생성

## #️⃣ 연관된 이슈

> ex) close #Issue number

## 📝 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

## 📷 스크린샷

> 이미지

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 명칭

### 📌 PR 진행 시 참고사항
- 리뷰어는 좋은 코드 방향을 제시하되, **수정을 강요하지 않습니다.**
- 좋은 코드를 발견하면 **칭찬과 격려를 아끼지 않습니다.**
- 리뷰는 Reviewer로 지정된 시점 기준으로 **3일 이내**에 진행해 주세요.
- Comment 작성 시 아래 Prefix를 사용해 주세요:
    - `P1`: 꼭 반영해 주세요 (Request Changes) – 이슈나 취약점 관련
    - `P2`: 반영을 고려해 주세요 (Comment) – 개선 의견
    - `P3`: 단순 제안 (Chore)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Users can set a nickname during registration; if omitted, a unique fallback nickname is generated automatically.

* **Improvements**
  * More precise nickname validation: spaces are not allowed; only Korean, English letters, and digits are permitted.
  * Clearer, user-friendly error messages when nickname rules are violated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->